### PR TITLE
Fix AAA dot1x YANG choice violations causing configuration drift

### DIFF
--- a/iosxe_aaa.tf
+++ b/iosxe_aaa.tf
@@ -173,22 +173,22 @@ resource "iosxe_aaa_authentication" "aaa_authentication" {
 
   dot1x = try(length(local.device_config[each.value.name].aaa.authentication.dot1xs) == 0, true) ? null : [for e in local.device_config[each.value.name].aaa.authentication.dot1xs : {
     name      = try(e.name, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.name, null)
-    a1_group  = try(!contains(["local", "cache", "radius"], try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0])), false) ? try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.logins.methods[0]) : null
-    a1_local  = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "local" ? true : false
-    a1_cache  = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "cache" ? true : false
-    a1_radius = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "radius" ? true : false
-    a2_group  = try(!contains(["local", "cache", "radius"], try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1])), false) ? try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.logins.methods[1]) : null
-    a2_local  = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "local" ? true : false
-    a2_cache  = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "cache" ? true : false
-    a2_radius = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "radius" ? true : false
-    a3_group  = try(!contains(["local", "cache", "radius"], try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2])), false) ? try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.logins.methods[2]) : null
-    a3_local  = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "local" ? true : false
-    a3_cache  = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "cache" ? true : false
-    a3_radius = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "radius" ? true : false
-    a4_group  = try(!contains(["local", "cache", "radius"], try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3])), false) ? try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.logins.methods[3]) : null
-    a4_local  = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "local" ? true : false
-    a4_cache  = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "cache" ? true : false
-    a4_radius = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "radius" ? true : false
+    a1_group  = try(!contains(["local", "cache", "radius"], try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0])), false) ? try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0]) : null
+    a1_local  = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "local" ? true : null
+    a1_cache  = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "cache" ? "cache" : null
+    a1_radius = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "radius" ? true : null
+    a2_group  = try(!contains(["local", "cache", "radius"], try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1])), false) ? try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1]) : null
+    a2_local  = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "local" ? true : null
+    a2_cache  = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "cache" ? "cache" : null
+    a2_radius = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "radius" ? true : null
+    a3_group  = try(!contains(["local", "cache", "radius"], try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2])), false) ? try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2]) : null
+    a3_local  = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "local" ? true : null
+    a3_cache  = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "cache" ? "cache" : null
+    a3_radius = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "radius" ? true : null
+    a4_group  = try(!contains(["local", "cache", "radius"], try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3])), false) ? try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3]) : null
+    a4_local  = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "local" ? true : null
+    a4_cache  = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "cache" ? "cache" : null
+    a4_radius = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "radius" ? true : null
   }]
 
   dot1x_default_a1_group = try(!contains(["local"], try(local.device_config[each.value.name].aaa.authentication.dot1x_defaults[0], local.defaults.iosxe.configuration.aaa.authentication.dot1x_defaults[0])), false) ? try(local.device_config[each.value.name].aaa.authentication.dot1x_defaults[0], local.defaults.iosxe.configuration.aaa.authentication.dot1x_defaults[0]) : null

--- a/iosxe_aaa.tf
+++ b/iosxe_aaa.tf
@@ -173,22 +173,23 @@ resource "iosxe_aaa_authentication" "aaa_authentication" {
 
   dot1x = try(length(local.device_config[each.value.name].aaa.authentication.dot1xs) == 0, true) ? null : [for e in local.device_config[each.value.name].aaa.authentication.dot1xs : {
     name      = try(e.name, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.name, null)
-    a1_group  = try(!contains(["local", "cache", "radius"], try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0])), false) ? try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0]) : null
-    a1_local  = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "local" ? true : null
-    a1_cache  = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "cache" ? "cache" : null
-    a1_radius = try(e.methods[0], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0], null) == "radius" ? true : null
-    a2_group  = try(!contains(["local", "cache", "radius"], try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1])), false) ? try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1]) : null
-    a2_local  = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "local" ? true : null
-    a2_cache  = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "cache" ? "cache" : null
-    a2_radius = try(e.methods[1], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1], null) == "radius" ? true : null
-    a3_group  = try(!contains(["local", "cache", "radius"], try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2])), false) ? try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2]) : null
-    a3_local  = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "local" ? true : null
-    a3_cache  = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "cache" ? "cache" : null
-    a3_radius = try(e.methods[2], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2], null) == "radius" ? true : null
-    a4_group  = try(!contains(["local", "cache", "radius"], try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3])), false) ? try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3]) : null
-    a4_local  = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "local" ? true : null
-    a4_cache  = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "cache" ? "cache" : null
-    a4_radius = try(e.methods[3], local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3], null) == "radius" ? true : null
+    a1_cache  = try(e.methods[0].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].cache, false) && try(e.methods[0].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].method, null) != null ? try(e.methods[0].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].method, null) : null
+    a1_local  = try(e.methods[0].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].method, null) == "local" ? true : null
+    a1_radius = try(e.methods[0].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].method, null) == "radius" ? true : null
+    a1_group  = !contains(["local", "radius"], try(e.methods[0].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].method, "")) && !try(e.methods[0].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].cache, false) ? try(e.methods[0].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[0].method, null) : null
+    a2_cache  = try(e.methods[1].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].cache, false) && try(e.methods[1].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].method, null) != null ? try(e.methods[1].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].method, null) : null
+    a2_local  = try(e.methods[1].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].method, null) == "local" ? true : null
+    a2_radius = try(e.methods[1].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].method, null) == "radius" ? true : null
+    a2_group  = !contains(["local", "radius"], try(e.methods[1].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].method, "")) && !try(e.methods[1].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].cache, false) ? try(e.methods[1].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[1].method, null) : null
+    a3_cache  = try(e.methods[2].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].cache, false) && try(e.methods[2].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].method, null) != null ? try(e.methods[2].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].method, null) : null
+    a3_local  = try(e.methods[2].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].method, null) == "local" ? true : null
+    a3_radius = try(e.methods[2].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].method, null) == "radius" ? true : null
+    a3_group  = !contains(["local", "radius"], try(e.methods[2].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].method, "")) && !try(e.methods[2].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].cache, false) ? try(e.methods[2].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[2].method, null) : null
+    # Method 4 (a4)
+    a4_cache  = try(e.methods[3].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].cache, false) && try(e.methods[3].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].method, null) != null ? try(e.methods[3].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].method, null) : null
+    a4_local  = try(e.methods[3].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].method, null) == "local" ? true : null
+    a4_radius = try(e.methods[3].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].method, null) == "radius" ? true : null
+    a4_group  = !contains(["local", "radius"], try(e.methods[3].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].method, "")) && !try(e.methods[3].cache, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].cache, false) ? try(e.methods[3].method, local.defaults.iosxe.configuration.aaa.authentication.dot1xs.methods[3].method, null) : null
   }]
 
   dot1x_default_a1_group = try(!contains(["local"], try(local.device_config[each.value.name].aaa.authentication.dot1x_defaults[0], local.defaults.iosxe.configuration.aaa.authentication.dot1x_defaults[0])), false) ? try(local.device_config[each.value.name].aaa.authentication.dot1x_defaults[0], local.defaults.iosxe.configuration.aaa.authentication.dot1x_defaults[0]) : null


### PR DESCRIPTION
 ## Summary

  Fixes critical YANG choice constraint violation in AAA dot1x/enable authentication
  configuration that caused state/reality drift and device configuration failures.

  ## Problems Fixed

  ### Problem 1: YANG Choice Constraint Violation

  When configuring dot1x authentication with custom RADIUS/TACACS+ groups:

  **Module Input:**
  ```hcl
  module "iosxe" {
    source = "./terraform-iosxe-nac-iosxe"

    # ... device config ...

    dot1xs = [
      {
        name    = "wired_auth"
        methods = ["local", "sw_radius_group"]
      }
    ]
  }
```

  Expected Device CLI:
```
  aaa authentication dot1x wired_auth local group sw_radius_group
```

  Actual Device CLI (before fix):
```
  aaa authentication dot1x wired_auth cache false cache false cache false cache false
```

  Terraform showed configuration applied successfully in state, but device had incorrect
  authentication methods configured.

  Problem 2: Array Index Logic Error

  Module was incorrectly checking methods[3] when evaluating methods[1], causing
  out-of-bounds errors and incorrect group name retrieval for authentication method lists.

  ---
  Root Causes

  1. YANG Choice Constraint Violation

  Module was violating YANG choice constraint by setting multiple mutually-exclusive options
   simultaneously.

  Provider Resource Arguments (before fix):
```tf
  resource "iosxe_aaa_authentication" "aaa_authentication" {
    dot1x = [
      {
        name      = "wired_auth"
        a1_local  = true
        a1_cache  = "false"              # Setting unused choice option
        a2_group  = "sw_radius_group"
        a2_cache  = "false"              # Setting unused choice option
      }
    ]
  }
```

  From Cisco-IOS-XE-aaa.yang:
```yang
  container a2-config {
    choice dot1x-auth {      // Only ONE can be set
      leaf group { type union { type string; } }
      leaf local { type empty; }
      leaf cache { type union { type string; } }
      leaf radius { type empty; }
    }
  }
```

  Issue: Module set unused choice options to false → Terraform coerced to string "false" →
  Provider serialized ALL values → RESTCONF applied last value (cache false) and ignored the
   intended value (group).

  2. Incorrect Array Indexing

  BEFORE (iosxe_aaa.tf):
```tf
  a2_group = try(!contains(["local", "cache", "radius"], try(e.methods[1], ...)), false) 
             ? try(e.methods[3], ...) : null  # Checking [3] when [1] fails
```

  AFTER (iosxe_aaa.tf):
```
  a2_group = !contains(["local", "radius"], try(e.methods[1].method, ...))
             ? try(e.methods[1].method, ...) : null  # Checking correct index
```
 
  ---
  Verification

  Device CLI (after fix):
```
  aaa authentication dot1x wired_auth local group sw_radius_group
```



