### PR TITLE
fix(class-maps)!: modify some class-map attributes to accept lists of primitives instead of standalone primitives

### DIFF
--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -21,34 +21,24 @@ locals {
         match_result_type_method_dot1x_method_timeout  = try(class_map.match.result_type_method_dot1x_method_timeout, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_method_timeout, null)
         match_method_mab                               = try(class_map.match.method_mab, local.defaults.iosxe.configuration.policy.class_maps.match.method_mab, null)
         match_result_type_method_mab_authoritative     = try(class_map.match.result_type_method_mab_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_mab_authoritative, null)
-        match_dscp = try(
-          length(class_map.match.dscp) > 0 ? [for v in class_map.match.dscp : tostring(v)] : null,
-          local.defaults.iosxe.configuration.policy.class_maps.match.dscp != null ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)] : null,
-          null
-        )
+        match_dscp = length(try(class_map.match.dscp, try(local.defaults.iosxe.configuration.policy.class_maps.match.dscp, []))) > 0 ? [
+          for v in try(class_map.match.dscp, local.defaults.iosxe.configuration.policy.class_maps.match.dscp) : tostring(v)
+        ] : null
         match_access_group_name = length(try(class_map.match.access_groups, try(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups, []))) > 0 ? try(class_map.match.access_groups, local.defaults.iosxe.configuration.policy.class_maps.match.access_groups) : (
           try(class_map.match.access_group, try(local.defaults.iosxe.configuration.policy.class_maps.match.access_group, null)) != null ? [try(class_map.match.access_group, local.defaults.iosxe.configuration.policy.class_maps.match.access_group)] : null
         )
-        match_ip_dscp = try(
-          # If it's already a list, convert to list of strings
-          can(tolist(class_map.match.ip_dscp)) ? [for v in class_map.match.ip_dscp : tostring(v)] : null,
-          # If it's a single value, wrap in list and convert to string
-          class_map.match.ip_dscp != null ? [tostring(class_map.match.ip_dscp)] : null,
-          # Try defaults (same logic)
-          can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp : tostring(v)] : null,
-          local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp != null ? [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)] : null,
-          null
-        )
-        match_ip_precedence = try(
-          # If it's already a list, convert to list of strings
-          can(tolist(class_map.match.ip_precedence)) ? [for v in class_map.match.ip_precedence : tostring(v)] : null,
-          # If it's a single value, wrap in list and convert to string
-          class_map.match.ip_precedence != null ? [tostring(class_map.match.ip_precedence)] : null,
-          # Try defaults (same logic)
-          can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence : tostring(v)] : null,
-          local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence != null ? [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)] : null,
-          null
-        )
+        match_ip_dscp = can(class_map.match.ip_dscp) || can(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp) ? [
+          for v in try(
+            can(tolist(class_map.match.ip_dscp)) ? tolist(class_map.match.ip_dscp) : [class_map.match.ip_dscp],
+            can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp) : [local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp]
+          ) : tostring(v)
+        ] : null
+        match_ip_precedence = can(class_map.match.ip_precedence) || can(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence) ? [
+          for v in try(
+            can(tolist(class_map.match.ip_precedence)) ? tolist(class_map.match.ip_precedence) : [class_map.match.ip_precedence],
+            can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence) : [local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence]
+          ) : tostring(v)
+        ] : null
         description = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
       }
     ]

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -21,24 +21,46 @@ locals {
         match_result_type_method_dot1x_method_timeout  = try(class_map.match.result_type_method_dot1x_method_timeout, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_method_timeout, null)
         match_method_mab                               = try(class_map.match.method_mab, local.defaults.iosxe.configuration.policy.class_maps.match.method_mab, null)
         match_result_type_method_mab_authoritative     = try(class_map.match.result_type_method_mab_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_mab_authoritative, null)
-        match_dscp = length(try(class_map.match.dscp, try(local.defaults.iosxe.configuration.policy.class_maps.match.dscp, []))) > 0 ? [
-          for v in try(class_map.match.dscp, local.defaults.iosxe.configuration.policy.class_maps.match.dscp) : tostring(v)
-        ] : null
-        match_access_group_name = length(try(class_map.match.access_groups, try(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups, []))) > 0 ? try(class_map.match.access_groups, local.defaults.iosxe.configuration.policy.class_maps.match.access_groups) : (
-          try(class_map.match.access_group, try(local.defaults.iosxe.configuration.policy.class_maps.match.access_group, null)) != null ? [try(class_map.match.access_group, local.defaults.iosxe.configuration.policy.class_maps.match.access_group)] : null
-        )
-        match_ip_dscp = can(class_map.match.ip_dscp) || can(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp) ? [
-          for v in try(
-            can(tolist(class_map.match.ip_dscp)) ? tolist(class_map.match.ip_dscp) : [class_map.match.ip_dscp],
-            can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp) : [local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp]
-          ) : tostring(v)
-        ] : null
-        match_ip_precedence = can(class_map.match.ip_precedence) || can(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence) ? [
-          for v in try(
-            can(tolist(class_map.match.ip_precedence)) ? tolist(class_map.match.ip_precedence) : [class_map.match.ip_precedence],
-            can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence) : [local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence]
-          ) : tostring(v)
-        ] : null
+        match_dscp = length(
+          compact(concat(
+            try([for v in class_map.match.dscp : tostring(v)], []),
+            try([for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)], [])
+          ))
+          ) > 0 ? tolist(compact(concat(
+            try([for v in class_map.match.dscp : tostring(v)], []),
+            try([for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)], [])
+        ))) : null
+        match_access_group_name = length(
+          compact(concat(
+            try(tolist(class_map.match.access_groups), []),
+            try([class_map.match.access_group], []),
+            try(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups), []),
+            try([local.defaults.iosxe.configuration.policy.class_maps.match.access_group], [])
+          ))
+          ) > 0 ? tolist(compact(concat(
+            try(tolist(class_map.match.access_groups), []),
+            try([class_map.match.access_group], []),
+            try(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups), []),
+            try([local.defaults.iosxe.configuration.policy.class_maps.match.access_group], [])
+        ))) : null
+        match_ip_dscp = length(
+          compact(concat(
+            try(can(tolist(class_map.match.ip_dscp)) ? [for v in class_map.match.ip_dscp : tostring(v)] : [tostring(class_map.match.ip_dscp)], []),
+            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)], [])
+          ))
+          ) > 0 ? tolist(compact(concat(
+            try(can(tolist(class_map.match.ip_dscp)) ? [for v in class_map.match.ip_dscp : tostring(v)] : [tostring(class_map.match.ip_dscp)], []),
+            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)], [])
+        ))) : null
+        match_ip_precedence = length(
+          compact(concat(
+            try(can(tolist(class_map.match.ip_precedence)) ? [for v in class_map.match.ip_precedence : tostring(v)] : [tostring(class_map.match.ip_precedence)], []),
+            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)], [])
+          ))
+          ) > 0 ? tolist(compact(concat(
+            try(can(tolist(class_map.match.ip_precedence)) ? [for v in class_map.match.ip_precedence : tostring(v)] : [tostring(class_map.match.ip_precedence)], []),
+            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)], [])
+        ))) : null
         description = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
       }
     ]

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -21,11 +21,42 @@ locals {
         match_result_type_method_dot1x_method_timeout  = try(class_map.match.result_type_method_dot1x_method_timeout, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_method_timeout, null)
         match_method_mab                               = try(class_map.match.method_mab, local.defaults.iosxe.configuration.policy.class_maps.match.method_mab, null)
         match_result_type_method_mab_authoritative     = try(class_map.match.result_type_method_mab_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_mab_authoritative, null)
-        match_dscp                                     = try(class_map.match.dscp, local.defaults.iosxe.configuration.policy.class_maps.match.dscp, null)
-        match_access_group_name                        = try(class_map.match.access_group, local.defaults.iosxe.configuration.policy.class_maps.match.access_group, null)
-        match_ip_dscp                                  = try(class_map.match.ip_dscp, local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp, null)
-        match_ip_precedence                            = try(class_map.match.ip_precedence, local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence, null)
-        description                                    = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
+        match_dscp = try(
+          length(class_map.match.dscp) > 0 ? [for v in class_map.match.dscp : tostring(v)] : null,
+          local.defaults.iosxe.configuration.policy.class_maps.match.dscp != null ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)] : null,
+          null
+        )
+        match_access_group_name = try(
+          # Prefer plural attribute
+          length(class_map.match.access_groups) > 0 ? class_map.match.access_groups : null,
+          # Fallback to singular (convert to list)
+          class_map.match.access_group != null ? [class_map.match.access_group] : null,
+          # Try defaults
+          length(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups) > 0 ? local.defaults.iosxe.configuration.policy.class_maps.match.access_groups : null,
+          local.defaults.iosxe.configuration.policy.class_maps.match.access_group != null ? [local.defaults.iosxe.configuration.policy.class_maps.match.access_group] : null,
+          null
+        )
+        match_ip_dscp = try(
+          # If it's already a list, convert to list of strings
+          can(tolist(class_map.match.ip_dscp)) ? [for v in class_map.match.ip_dscp : tostring(v)] : null,
+          # If it's a single value, wrap in list and convert to string
+          class_map.match.ip_dscp != null ? [tostring(class_map.match.ip_dscp)] : null,
+          # Try defaults (same logic)
+          can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp : tostring(v)] : null,
+          local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp != null ? [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)] : null,
+          null
+        )
+        match_ip_precedence = try(
+          # If it's already a list, convert to list of strings
+          can(tolist(class_map.match.ip_precedence)) ? [for v in class_map.match.ip_precedence : tostring(v)] : null,
+          # If it's a single value, wrap in list and convert to string
+          class_map.match.ip_precedence != null ? [tostring(class_map.match.ip_precedence)] : null,
+          # Try defaults (same logic)
+          can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence : tostring(v)] : null,
+          local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence != null ? [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)] : null,
+          null
+        )
+        description = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
       }
     ]
   ])

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -14,17 +14,17 @@ locals {
         match_activated_service_templates = try(length(class_map.match.activated_service_templates) == 0, true) ? null : [for template in class_map.match.activated_service_templates : {
           service_name = try(template.service_name, local.defaults.iosxe.configuration.policy.class_maps.match.activated_service_templates.service_name, null)
         }]
-        match_authorizing_method_priority_greater_than = can(class_map.match.authorizing_method_priority_greater_than) ? class_map.match.authorizing_method_priority_greater_than : null
+        match_authorizing_method_priority_greater_than = can(class_map.match.authorizing_method_priority_greater_than) ? sort(class_map.match.authorizing_method_priority_greater_than) : null
         match_method_dot1x                             = try(class_map.match.method_dot1x, local.defaults.iosxe.configuration.policy.class_maps.match.method_dot1x, null)
         match_result_type_method_dot1x_authoritative   = try(class_map.match.result_type_method_dot1x_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_authoritative, null)
         match_result_type_method_dot1x_agent_not_found = try(class_map.match.result_type_method_dot1x_agent_not_found, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_agent_not_found, null)
         match_result_type_method_dot1x_method_timeout  = try(class_map.match.result_type_method_dot1x_method_timeout, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_method_timeout, null)
         match_method_mab                               = try(class_map.match.method_mab, local.defaults.iosxe.configuration.policy.class_maps.match.method_mab, null)
         match_result_type_method_mab_authoritative     = try(class_map.match.result_type_method_mab_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_mab_authoritative, null)
-        match_dscp                                     = can(class_map.match.dscp) ? class_map.match.dscp : null
-        match_access_group_name                        = can(class_map.match.access_groups) ? class_map.match.access_groups : null
-        match_ip_dscp                                  = can(class_map.match.ip_dscp) ? class_map.match.ip_dscp : null
-        match_ip_precedence                            = can(class_map.match.ip_precedence) ? class_map.match.ip_precedence : null
+        match_dscp                                     = can(class_map.match.dscp) ? sort(class_map.match.dscp) : null
+        match_access_group_name                        = can(class_map.match.access_groups) ? sort(class_map.match.access_groups) : null
+        match_ip_dscp                                  = can(class_map.match.ip_dscp) ? sort(class_map.match.ip_dscp) : null
+        match_ip_precedence                            = can(class_map.match.ip_precedence) ? sort(class_map.match.ip_precedence) : null
         description                                    = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
       }
     ]

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -26,15 +26,8 @@ locals {
           local.defaults.iosxe.configuration.policy.class_maps.match.dscp != null ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)] : null,
           null
         )
-        match_access_group_name = try(
-          # Prefer plural attribute
-          length(class_map.match.access_groups) > 0 ? class_map.match.access_groups : null,
-          # Fallback to singular (convert to list)
-          class_map.match.access_group != null ? [class_map.match.access_group] : null,
-          # Try defaults
-          length(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups) > 0 ? local.defaults.iosxe.configuration.policy.class_maps.match.access_groups : null,
-          local.defaults.iosxe.configuration.policy.class_maps.match.access_group != null ? [local.defaults.iosxe.configuration.policy.class_maps.match.access_group] : null,
-          null
+        match_access_group_name = length(try(class_map.match.access_groups, try(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups, []))) > 0 ? try(class_map.match.access_groups, local.defaults.iosxe.configuration.policy.class_maps.match.access_groups) : (
+          try(class_map.match.access_group, try(local.defaults.iosxe.configuration.policy.class_maps.match.access_group, null)) != null ? [try(class_map.match.access_group, local.defaults.iosxe.configuration.policy.class_maps.match.access_group)] : null
         )
         match_ip_dscp = try(
           # If it's already a list, convert to list of strings

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -14,54 +14,18 @@ locals {
         match_activated_service_templates = try(length(class_map.match.activated_service_templates) == 0, true) ? null : [for template in class_map.match.activated_service_templates : {
           service_name = try(template.service_name, local.defaults.iosxe.configuration.policy.class_maps.match.activated_service_templates.service_name, null)
         }]
-        match_authorizing_method_priority_greater_than = try(class_map.match.authorizing_method_priority_greater_than, local.defaults.iosxe.configuration.policy.class_maps.match.authorizing_method_priority_greater_than, null)
+        match_authorizing_method_priority_greater_than = can(class_map.match.authorizing_method_priority_greater_than) ? class_map.match.authorizing_method_priority_greater_than : null
         match_method_dot1x                             = try(class_map.match.method_dot1x, local.defaults.iosxe.configuration.policy.class_maps.match.method_dot1x, null)
         match_result_type_method_dot1x_authoritative   = try(class_map.match.result_type_method_dot1x_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_authoritative, null)
         match_result_type_method_dot1x_agent_not_found = try(class_map.match.result_type_method_dot1x_agent_not_found, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_agent_not_found, null)
         match_result_type_method_dot1x_method_timeout  = try(class_map.match.result_type_method_dot1x_method_timeout, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_dot1x_method_timeout, null)
         match_method_mab                               = try(class_map.match.method_mab, local.defaults.iosxe.configuration.policy.class_maps.match.method_mab, null)
         match_result_type_method_mab_authoritative     = try(class_map.match.result_type_method_mab_authoritative, local.defaults.iosxe.configuration.policy.class_maps.match.result_type_method_mab_authoritative, null)
-        match_dscp = length(
-          compact(concat(
-            try([for v in class_map.match.dscp : tostring(v)], []),
-            try([for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)], [])
-          ))
-          ) > 0 ? tolist(compact(concat(
-            try([for v in class_map.match.dscp : tostring(v)], []),
-            try([for v in local.defaults.iosxe.configuration.policy.class_maps.match.dscp : tostring(v)], [])
-        ))) : null
-        match_access_group_name = length(
-          compact(concat(
-            try(tolist(class_map.match.access_groups), []),
-            try([class_map.match.access_group], []),
-            try(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups), []),
-            try([local.defaults.iosxe.configuration.policy.class_maps.match.access_group], [])
-          ))
-          ) > 0 ? tolist(compact(concat(
-            try(tolist(class_map.match.access_groups), []),
-            try([class_map.match.access_group], []),
-            try(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.access_groups), []),
-            try([local.defaults.iosxe.configuration.policy.class_maps.match.access_group], [])
-        ))) : null
-        match_ip_dscp = length(
-          compact(concat(
-            try(can(tolist(class_map.match.ip_dscp)) ? [for v in class_map.match.ip_dscp : tostring(v)] : [tostring(class_map.match.ip_dscp)], []),
-            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)], [])
-          ))
-          ) > 0 ? tolist(compact(concat(
-            try(can(tolist(class_map.match.ip_dscp)) ? [for v in class_map.match.ip_dscp : tostring(v)] : [tostring(class_map.match.ip_dscp)], []),
-            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_dscp)], [])
-        ))) : null
-        match_ip_precedence = length(
-          compact(concat(
-            try(can(tolist(class_map.match.ip_precedence)) ? [for v in class_map.match.ip_precedence : tostring(v)] : [tostring(class_map.match.ip_precedence)], []),
-            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)], [])
-          ))
-          ) > 0 ? tolist(compact(concat(
-            try(can(tolist(class_map.match.ip_precedence)) ? [for v in class_map.match.ip_precedence : tostring(v)] : [tostring(class_map.match.ip_precedence)], []),
-            try(can(tolist(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)) ? [for v in local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence : tostring(v)] : [tostring(local.defaults.iosxe.configuration.policy.class_maps.match.ip_precedence)], [])
-        ))) : null
-        description = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
+        match_dscp                                     = can(class_map.match.dscp) ? class_map.match.dscp : null
+        match_access_group_name                        = can(class_map.match.access_groups) ? class_map.match.access_groups : null
+        match_ip_dscp                                  = can(class_map.match.ip_dscp) ? class_map.match.ip_dscp : null
+        match_ip_precedence                            = can(class_map.match.ip_precedence) ? class_map.match.ip_precedence : null
+        description                                    = try(class_map.description, local.defaults.iosxe.configuration.policy.class_maps.description, null)
       }
     ]
   ])


### PR DESCRIPTION
**This is a breaking change**; however, the previous implementation did not seem to fully work, so the impact of this breaking change to functioning environments is anticipated to be minimal.

This PR modifies the type of the following data model attributes from their respective primitives (strings, integers, etc.) to *lists* of their respective primitives. Not only does this match what the underlying YANG model is expecting, but it also enhances the capabilities of how users are able to configure class maps on their IOS-XE network devices.

- `authorizing_method_priority_greater_than`
- `dscp`
- `access_groups`
- `ip_dscp`
- `ip_precedence`

Additionally, the `access_group` attribute has been renamed to `access_groups`, which better communicates the expectation that a *list* of strings should follow the attribute (as opposed to a single string).