### PR TITLE
[Route-Map] Add Advanced Set Actions Support in Terraform Module

### DIFF
--- a/iosxe_route_maps.tf
+++ b/iosxe_route_maps.tf
@@ -71,6 +71,7 @@ locals {
           set_ip_global_next_hop_address             = try(e.set.ipv4_global_next_hop_addresses, local.defaults.iosxe.configuration.route_maps.entries.set.ipv4_global_next_hop_addresses, null)
           set_ip_next_hop_address                    = try(e.set.ipv4_next_hop_addresses, local.defaults.iosxe.configuration.route_maps.entries.set.ipv4_next_hop_addresses, null)
           set_ip_next_hop_self                       = try(e.set.ipv4_next_hop_self, local.defaults.iosxe.configuration.route_maps.entries.set.ipv4_next_hop_self, null)
+          set_ip_next_hop_unchanged                  = try(e.set.ipv4_next_hop_unchanged, local.defaults.iosxe.configuration.route_maps.entries.set.ipv4_next_hop_unchanged, null)
           set_ip_qos_group                           = try(e.set.ipv4_qos_group, local.defaults.iosxe.configuration.route_maps.entries.set.ipv4_qos_group, null)
           set_ipv6_address                           = try(e.set.ipv6_addresses, local.defaults.iosxe.configuration.route_maps.entries.set.ipv6_addresses, null)
           set_ipv6_default_global_next_hop           = try(e.set.ipv6_default_global_next_hop, local.defaults.iosxe.configuration.route_maps.entries.set.ipv6_default_global_next_hop, null)


### PR DESCRIPTION
Add support for route-map advanced set actions enabling next-hop preservation and well-known BGP community configuration:

- set ip next-hop unchanged
- set community [no-export|no-advertise|internet|local-AS]

This enhancement allows route-maps to preserve next-hop information and configure well-known BGP communities for advanced routing policies.