### PR TITLE
[AAA] Implement RADIUS-Server Attribute Support in Terraform Module

### DIFF
--- a/iosxe_aaa.tf
+++ b/iosxe_aaa.tf
@@ -365,9 +365,8 @@ resource "iosxe_radius_server" "radius_server" {
 
   attributes = try(length(local.device_config[each.value.name].aaa.radius.attributes) == 0, true) ? null : [for attr in local.device_config[each.value.name].aaa.radius.attributes :
     {
-      number                 = try(attr.number, local.defaults.iosxe.configuration.aaa.radius.attributes.number, null)
-      access_request_include = try(attr.access_request_include, local.defaults.iosxe.configuration.aaa.radius.attributes.access_request_include, null)
-      send_attributes        = try(attr.send_attributes, local.defaults.iosxe.configuration.aaa.radius.attributes.send_attributes, null)
+      number          = try(attr.number, local.defaults.iosxe.configuration.aaa.radius.attributes.number, null)
+      send_attributes = try(attr.send_attributes, local.defaults.iosxe.configuration.aaa.radius.attributes.send_attributes, null)
       attribute_31_parameters = try(length(attr.attribute_31_parameters) == 0, true) ? null : [for param in attr.attribute_31_parameters :
         {
           calling_station_id      = try(param.calling_station_id, local.defaults.iosxe.configuration.aaa.radius.attributes.attribute_31_parameters.calling_station_id, null)


### PR DESCRIPTION
## Refactor: Standardize RADIUS attribute configuration on send_attributes

Remove support for the access_request_include boolean attribute and standardize on the send_attributes list approach for configuring RADIUS server attribute 25:

### New standardized approach:
This refactoring aligns the NAC module with the updated provider (v0.10.0) and provides a consistent configuration pattern for all RADIUS attributes (6, 8, 25, etc.), improving maintainability and user experience.

**Breaking Change:** Users must migrate existing configurations from access_request_include to send_attributes before upgrading.
**Dependencies:** Requires terraform-provider-iosxe >= 0.10.0

- Remove access_request_include mapping from iosxe_aaa module
- Users should use send_attributes with 'include-in-access-req' instead
- This aligns with the provider changes removing this attribute