### PR TITLE
fix: correct update_source attribute names for BGP resources

### DIFF
--- a/iosxe_bgp.tf
+++ b/iosxe_bgp.tf
@@ -46,7 +46,7 @@ locals {
         timers_holdtime                           = try(neighbor.timers_holdtime, local.defaults.iosxe.configuration.routing.bgp.neighbors.timers_holdtime, null)
         timers_minimum_neighbor_hold              = try(neighbor.timers_minimum_neighbor_holdtime, local.defaults.iosxe.configuration.routing.bgp.neighbors.timers_minimum_neighbor_holdtime, null)
         ttl_security_hops                         = try(neighbor.ttl_security_hops, local.defaults.iosxe.configuration.routing.bgp.neighbors.ttl_security_hops, null)
-        update_source_loopback                    = try(neighbor.update_source_interface_type, local.defaults.iosxe.configuration.routing.bgp.neighbors.update_source_interface_type, null) == "Loopback" ? try(neighbor.update_source_interface_id, local.defaults.iosxe.configuration.routing.bgp.neighbors.update_source_interface_id, null) : null
+        update_source_interface_loopback          = try(neighbor.update_source_interface_type, local.defaults.iosxe.configuration.routing.bgp.neighbors.update_source_interface_type, null) == "Loopback" ? try(neighbor.update_source_interface_id, local.defaults.iosxe.configuration.routing.bgp.neighbors.update_source_interface_id, null) : null
         ebgp_multihop                             = try(neighbor.ebgp_multihop, local.defaults.iosxe.configuration.routing.bgp.neighbors.ebgp_multihop, null)
         ebgp_multihop_max_hop                     = try(neighbor.ebgp_multihop_max_hop, local.defaults.iosxe.configuration.routing.bgp.neighbors.ebgp_multihop_max_hop, null)
       }
@@ -85,7 +85,7 @@ resource "iosxe_bgp_neighbor" "bgp_neighbor" {
   timers_holdtime                           = each.value.timers_holdtime
   timers_minimum_neighbor_hold              = each.value.timers_minimum_neighbor_hold
   ttl_security_hops                         = each.value.ttl_security_hops
-  update_source_loopback                    = each.value.update_source_loopback
+  update_source_interface_loopback          = each.value.update_source_interface_loopback
   ebgp_multihop                             = each.value.ebgp_multihop
   ebgp_multihop_max_hop                     = each.value.ebgp_multihop_max_hop
 }


### PR DESCRIPTION
## Summary

Updates BGP neighbor attribute names to match provider changes from [CiscoDevNet/terraform-provider-iosxe#329](https://github.com/CiscoDevNet/terraform-provider-iosxe/pull/329).

## Changes

- Updates `iosxe_bgp_neighbor` resource to use `update_source_interface_loopback` (renamed in provider PR #329)
- Keeps `iosxe_bgp_ipv4_unicast_vrf_neighbor` resource using `update_source_loopback` (not renamed in provider PR #329)

## Provider Inconsistency

The provider currently has an inconsistency where the `update_source_loopback` attribute was renamed to `update_source_interface_loopback` in the `iosxe_bgp_neighbor` resource, but the same attribute in the `iosxe_bgp_ipv4_unicast_vrf_neighbor` resource was not renamed and still uses `update_source_loopback`. 

This PR updates the module to match the current provider state. A follow-up PR to the provider may be beneficial to rename the VRF neighbor attribute to `update_source_interface_loopback` for consistency across both BGP neighbor resources.