### PR TITLE
  fix: complete BGP VRF neighbor attribute rename for update_source_interface_loopback

### DIFF
--- a/iosxe_bgp.tf
+++ b/iosxe_bgp.tf
@@ -365,7 +365,7 @@ locals {
           local_as_no_prepend                       = try(neighbor.local_as_no_prepend, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.local_as_no_prepend, null)
           local_as_replace_as                       = try(neighbor.local_as_replace_as, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.local_as_replace_as, null)
           local_as_dual_as                          = try(neighbor.local_as_dual_as, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.local_as_dual_as, null)
-          update_source_loopback                    = try(neighbor.update_source_interface_type, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.update_source_interface_type, null) == "Loopback" ? try(neighbor.update_source_interface_id, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.update_source_interface_id, null) : null
+          update_source_interface_loopback          = try(neighbor.update_source_interface_type, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.update_source_interface_type, null) == "Loopback" ? try(neighbor.update_source_interface_id, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.update_source_interface_id, null) : null
           activate                                  = try(neighbor.activate, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.activate, true)
           send_community                            = try(neighbor.send_community, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.send_community, null)
           route_reflector_client                    = try(neighbor.route_reflector_client, local.defaults.iosxe.configuration.routing.bgp.address_family.ipv4_unicast.vrfs.neighbors.route_reflector_client, null)
@@ -418,7 +418,7 @@ resource "iosxe_bgp_ipv4_unicast_vrf_neighbor" "bgp_ipv4_unicast_vrf_neighbor" {
   local_as_no_prepend                       = each.value.local_as_no_prepend
   local_as_replace_as                       = each.value.local_as_replace_as
   local_as_dual_as                          = each.value.local_as_dual_as
-  update_source_loopback                    = each.value.update_source_loopback
+  update_source_interface_loopback          = each.value.update_source_interface_loopback
   activate                                  = each.value.activate
   send_community                            = each.value.send_community
   route_reflector_client                    = each.value.route_reflector_client


### PR DESCRIPTION
  This PR completes the attribute renaming for `iosxe_bgp_ipv4_unicast_vrf_neighbor` resource to use
  `update_source_interface_loopback` instead of `update_source_loopback`, aligning with the provider's changes.

## Problem

```bash
(IOSXE-as-Code) administrator@svs-atestini-ubuntu-2404-jumpbox:~/$ terraform plan -out=plan.tfplan -input=false -lock=false 2>&1 | tee ./terraform_plan_output.txt
<snip for brevity>
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/iosxe/iosxe_bgp.tf line 421, in resource "iosxe_bgp_ipv4_unicast_vrf_neighbor" "bgp_ipv4_unicast_vrf_neighbor":
│  421:   update_source_loopback                    = each.value.update_source_loopback
│ 
│ An argument named "update_source_loopback" is not expected here.
╵
```
  ### Timeline of Changes:

  1. **Provider PR [#329](https://github.com/CiscoDevNet/terraform-provider-iosxe/pull/329)** - Renamed `update_source_loopback` to
   `update_source_interface_loopback` for `iosxe_bgp_neighbor` resource only (VRF neighbor was NOT changed)

  2. **Module PR [#85](https://github.com/netascode/terraform-iosxe-nac-iosxe/pull/85)** (Nov 7, 2024) - Updated module to match
  provider state at that time:
     - Updated `iosxe_bgp_neighbor` to use `update_source_interface_loopback`
     - Kept `iosxe_bgp_ipv4_unicast_vrf_neighbor` using `update_source_loopback` (intentionally, as provider hadn't changed it
  yet)

  3. **Provider PR [#346](https://github.com/CiscoDevNet/terraform-provider-iosxe/pull/346)** - Later renamed the VRF neighbor
  attribute to `update_source_interface_loopback` for consistency

  4. **This PR** - Updates the module to match the provider's current state after PR #346

  ## Changes

  Updates the `iosxe_bgp_ipv4_unicast_vrf_neighbor` resource to use `update_source_interface_loopback`:
  - Line 368: Updated attribute name in locals block
  - Line 421: Updated attribute name in resource block

  This completes the attribute renaming across all BGP neighbor resources, ensuring both regular and VRF neighbors use the standardized `update_source_interface_loopback` attribute name.