### PR TITLE
fix: change some interface attribute defaults from false to null

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -12,7 +12,7 @@ locals {
         bandwidth                               = try(int.bandwidth, local.defaults.iosxe.devices.configuration.interfaces.ethernets.bandwidth, null)
         mtu                                     = try(int.mtu, local.defaults.iosxe.devices.configuration.interfaces.ethernets.mtu, null)
         description                             = try(int.description, local.defaults.iosxe.devices.configuration.interfaces.ethernets.description, null)
-        shutdown                                = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.ethernets.shutdown, false)
+        shutdown                                = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.ethernets.shutdown, null)
         vrf_forwarding                          = try(int.vrf_forwarding, local.defaults.iosxe.devices.configuration.interfaces.ethernets.vrf_forwarding, null)
         ipv4_address                            = try(int.ipv4.address, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.address, null)
         ipv4_address_mask                       = try(int.ipv4.address_mask, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.address_mask, null)
@@ -28,9 +28,9 @@ locals {
           vrf     = try(ha.vrf, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.helper_addresses.vrf, null)
         }]
         ip_access_group_in         = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.access_group_in, null)
-        ip_access_group_in_enable  = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.access_group_in, null) != null ? true : false
+        ip_access_group_in_enable  = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.access_group_in, null) != null ? true : null
         ip_access_group_out        = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.access_group_out, null)
-        ip_access_group_out_enable = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.access_group_out, null) != null ? true : false
+        ip_access_group_out_enable = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.access_group_out, null) != null ? true : null
         ip_flow_monitors = try(length(int.ipv4.flow_monitors) == 0, true) ? null : [for fm in int.ipv4.flow_monitors : {
           name      = try(fm.name, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.flow_monitors.name, null)
           direction = try(fm.direction, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv4.flow_monitors.direction, null)
@@ -447,15 +447,15 @@ locals {
         device                     = device.name
         id                         = int.id
         description                = try(int.description, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.description, null)
-        shutdown                   = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.shutdown, false)
+        shutdown                   = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.shutdown, null)
         vrf_forwarding             = try(int.vrf_forwarding, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.vrf_forwarding, null)
         ipv4_address               = try(int.ipv4.address, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.address, null)
         ipv4_address_mask          = try(int.ipv4.address_mask, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.address_mask, null)
         ip_proxy_arp               = try(int.ipv4.proxy_arp, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.proxy_arp, null)
         ip_access_group_in         = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.access_group_in, null)
-        ip_access_group_in_enable  = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.access_group_in, null) != null ? true : false
+        ip_access_group_in_enable  = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.access_group_in, null) != null ? true : null
         ip_access_group_out        = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.access_group_out, null)
-        ip_access_group_out_enable = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.access_group_out, null) != null ? true : false
+        ip_access_group_out_enable = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.access_group_out, null) != null ? true : null
         ip_redirects               = try(int.ipv4.redirects, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.redirects, null)
         ip_unreachables            = try(int.ipv4.unreachables, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv4.unreachables, null)
         source_template            = try(int.source_template, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.source_template, [])
@@ -646,7 +646,7 @@ locals {
         id                                      = int.id
         type                                    = try(int.type, local.defaults.iosxe.devices.configuration.interfaces.vlans.type, null)
         description                             = try(int.description, local.defaults.iosxe.devices.configuration.interfaces.vlans.description, null)
-        shutdown                                = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.vlans.shutdown, false)
+        shutdown                                = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.vlans.shutdown, null)
         autostate                               = try(int.autostate, local.defaults.iosxe.devices.configuration.interfaces.vlans.autostate, null)
         vrf_forwarding                          = try(int.vrf_forwarding, local.defaults.iosxe.devices.configuration.interfaces.vlans.vrf_forwarding, null)
         ipv4_address                            = try(int.ipv4.address, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.address, null)
@@ -661,9 +661,9 @@ locals {
           vrf     = try(ha.vrf, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.helper_addresses.vrf, null)
         }]
         ip_access_group_in         = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.access_group_in, null)
-        ip_access_group_in_enable  = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.access_group_in, null) != null ? true : false
+        ip_access_group_in_enable  = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.access_group_in, null) != null ? true : null
         ip_access_group_out        = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.access_group_out, null)
-        ip_access_group_out_enable = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.access_group_out, null) != null ? true : false
+        ip_access_group_out_enable = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.access_group_out, null) != null ? true : null
         ip_redirects               = try(int.ipv4.redirects, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.redirects, null)
         ip_unreachables            = try(int.ipv4.unreachables, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.unreachables, null)
         unnumbered                 = try("${try(int.ipv4.unnumbered_interface_type, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.unnumbered_interface_type)}${try(int.ipv4.unnumbered_interface_id, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv4.unnumbered_interface_id)}", null)
@@ -870,16 +870,16 @@ locals {
         device                         = device.name
         name                           = trimprefix(int.id, "$string ")
         description                    = try(int.description, local.defaults.iosxe.devices.configuration.interfaces.port_channels.description, null)
-        shutdown                       = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.port_channels.shutdown, false)
+        shutdown                       = try(int.shutdown, local.defaults.iosxe.devices.configuration.interfaces.port_channels.shutdown, null)
         vrf_forwarding                 = try(int.vrf_forwarding, local.defaults.iosxe.devices.configuration.interfaces.port_channels.vrf_forwarding, null)
         ipv4_address                   = try(int.ipv4.address, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.address, null)
         ipv4_address_mask              = try(int.ipv4.address_mask, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.address_mask, null)
         ip_proxy_arp                   = try(int.ipv4.proxy_arp, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.proxy_arp, null)
         ip_dhcp_relay_source_interface = try(int.ipv4.dhcp_relay_source_interface_type, int.ipv4.dhcp_relay_source_interface_id, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.dhcp_relay_source_interface_type, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.dhcp_relay_source_interface_id, null) != null ? format("%s%s", try(int.ipv4.dhcp_relay_source_interface_type, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.dhcp_relay_source_interface_type), try(int.ipv4.dhcp_relay_source_interface_id, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.dhcp_relay_source_interface_id)) : null
         ip_access_group_in             = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.access_group_in, null)
-        ip_access_group_in_enable      = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.access_group_in, null) != null ? true : false
+        ip_access_group_in_enable      = try(int.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.access_group_in, null) != null ? true : null
         ip_access_group_out            = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.access_group_out, null)
-        ip_access_group_out_enable     = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.access_group_out, null) != null ? true : false
+        ip_access_group_out_enable     = try(int.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.access_group_out, null) != null ? true : null
         ip_redirects                   = try(int.ipv4.redirects, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.redirects, null)
         ip_unreachables                = try(int.ipv4.unreachables, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.unreachables, null)
         ip_arp_inspection_trust        = try(int.ipv4.arp_inspection_trust, local.defaults.iosxe.devices.configuration.interfaces.port_channels.ipv4.arp_inspection_trust, null)
@@ -1183,7 +1183,7 @@ locals {
           device                       = device.name
           name                         = trimprefix(sub.id, "$string ")
           description                  = try(sub.description, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.description, null)
-          shutdown                     = try(sub.shutdown, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.shutdown, false)
+          shutdown                     = try(sub.shutdown, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.shutdown, null)
           vrf_forwarding               = try(sub.vrf_forwarding, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.vrf_forwarding, null)
           ipv4_address                 = try(sub.ipv4.address, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.address, null)
           ipv4_address_mask            = try(sub.ipv4.address_mask, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.address_mask, null)
@@ -1196,9 +1196,9 @@ locals {
             vrf     = try(ha.vrf, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.helper_addresses.vrf, null)
           }]
           ip_access_group_in         = try(sub.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.access_group_in, null)
-          ip_access_group_in_enable  = try(sub.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.access_group_in, null) != null ? true : false
+          ip_access_group_in_enable  = try(sub.ipv4.access_group_in, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.access_group_in, null) != null ? true : null
           ip_access_group_out        = try(sub.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.access_group_out, null)
-          ip_access_group_out_enable = try(sub.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.access_group_out, null) != null ? true : false
+          ip_access_group_out_enable = try(sub.ipv4.access_group_out, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.access_group_out, null) != null ? true : null
           ip_redirects               = try(sub.ipv4.redirects, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.redirects, null)
           ip_unreachables            = try(sub.ipv4.unreachables, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv4.unreachables, null)
           ipv6_enable                = try(sub.ipv6.enable, local.defaults.iosxe.devices.configuration.interfaces.port_channels.subinterfaces.ipv6.enable, null)


### PR DESCRIPTION
## Summary

This PR addresses a bug where defining minimal interface configurations in the data model results in
Terraform showing unintended attribute changes during `terraform plan` and `terraform apply`.

When interfaces are defined with minimal configuration (e.g., just `type` and `id`), Terraform was
incorrectly planning to set `shutdown`, `ip_access_group_in_enable`, and `ip_access_group_out_enable` to
`false`, even though these attributes were not specified in the data model or defaults.

A simple example of this is through the data model below:

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      url: https://192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        interfaces:
          ethernets:
            - type: GigabitEthernet
              id: 1/0/3
```

When this data model is applied via `terraform apply`, Terraform will show the following output:

```text
Terraform will perform the following actions:

  # module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"] will be created
  + resource "iosxe_interface_ethernet" "ethernet" {
      + device                     = "xeac-cat9kv-uadp-1"
      + id                         = (known after apply)
      + ip_access_group_in_enable  = false
      + ip_access_group_out_enable = false
      + name                       = "1/0/3"
      + shutdown                   = false
      + type                       = "GigabitEthernet"
    }
```

## Root Cause

The Terraform module was defaulting these attributes to `false` instead of `null`. This forced Terraform to
explicitly configure these attributes on the device, rather than allowing the YANG model to use the device's
default values.

## Changes

Changed the following attribute defaults from `false` to `null` across all interface types:

- `shutdown`
- `ip_access_group_in_enable`
- `ip_access_group_out_enable`

This affects the following interface types:

- Ethernet interfaces
- Loopback interfaces
- VLAN interfaces
- Port-channel interfaces
- Port-channel subinterfaces

## Evidence

### Ethernet interface

<details>
<summary>Ethernet interface evidence</summary>

Data model:

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      url: https://192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        interfaces:
          ethernets:
            - type: GigabitEthernet
              id: 1/0/3
```

`terraform apply` output:

```text
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=29bbda1d4a08e27a5a1a7578fbb7bea19d95656a]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"] will be created
  + resource "iosxe_interface_ethernet" "ethernet" {
      + device = "xeac-cat9kv-uadp-1"
      + id     = (known after apply)
      + name   = "1/0/3"
      + type   = "GigabitEthernet"
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "Wbmi3/1PzVe4KGNyiiNbLOemUmaXa/rzUYkVRibeymI=" -> (known after apply)
      ~ content_base64sha512 = "10LXWWxeFR8YhEWBzxFYhK9lyu3UIuS8otr8Qj7GEC1h2RTyuKDQc4FfZypr1oJk1SXQQ6O4QJXiuC/02dWsHA==" -> (known after apply)
      ~ content_md5          = "24d73490277d3b914fb6d5d70833aa2f" -> (known after apply)
      ~ content_sha1         = "29bbda1d4a08e27a5a1a7578fbb7bea19d95656a" -> (known after apply)
      ~ content_sha256       = "59b9a2dffd4fcd57b82863728a235b2ce7a65266976bfaf35189154626deca62" -> (known after apply)
      ~ content_sha512       = "d742d7596c5e151f18844581cf115884af65caedd422e4bca2dafc423ec6102d61d914f2b8a0d073815f672a6bd68264d525d043a3b84095e2b82ff4d9d5ac1c" -> (known after apply)
      ~ id                   = "29bbda1d4a08e27a5a1a7578fbb7bea19d95656a" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=29bbda1d4a08e27a5a1a7578fbb7bea19d95656a]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=029aab6693fd60cfcdcd1501580395f4836629ff]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Creating...
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
➜  nac-testing git:(main) ✗ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=029aab6693fd60cfcdcd1501580395f4836629ff]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
│
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

</details>

### Loopback interface

<details>
<summary>Loopback interface evidence</summary>

Data model:

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      url: https://192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        interfaces:
          loopbacks:
            - id: 100
```

`terraform apply` output:

```text
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=029aab6693fd60cfcdcd1501580395f4836629ff]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"] will be created
  + resource "iosxe_interface_loopback" "loopback" {
      + device = "xeac-cat9kv-uadp-1"
      + id     = (known after apply)
      + name   = 100
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "kuMP3ubKRWHcL3Zp1oxmLrL2J+VS6JZv1338EcHo7lc=" -> (known after apply)
      ~ content_base64sha512 = "JYYltxIC61cGDDyBPVwWBleAVcCAgGMqbJEXi829WM6jjMfN8RDniUo/5QiNlODyXegJm/NLef2mxFOASwoISA==" -> (known after apply)
      ~ content_md5          = "a6bcead2ac8b17aaea648ba218387dc5" -> (known after apply)
      ~ content_sha1         = "029aab6693fd60cfcdcd1501580395f4836629ff" -> (known after apply)
      ~ content_sha256       = "92e30fdee6ca4561dc2f7669d68c662eb2f627e552e8966fd77dfc11c1e8ee57" -> (known after apply)
      ~ content_sha512       = "258625b71202eb57060c3c813d5c1606578055c08080632a6c91178bcdbd58cea38cc7cdf110e7894a3fe5088d94e0f25de8099bf34b79fda6c453804b0a0848" -> (known after apply)
      ~ id                   = "029aab6693fd60cfcdcd1501580395f4836629ff" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=029aab6693fd60cfcdcd1501580395f4836629ff]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=9871970642a22c0b80459e7e4a9aebbdba283e64]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Creation complete after 0s [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
➜  nac-testing git:(main) ✗ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=9871970642a22c0b80459e7e4a9aebbdba283e64]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
│
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

</details>

### VLAN interface

<details>
<summary>VLAN interface evidence</summary>

Data model:

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      url: https://192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        interfaces:
          vlans:
            - id: 100
```

`terraform apply` output:

```text
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=9871970642a22c0b80459e7e4a9aebbdba283e64]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"] will be created
  + resource "iosxe_interface_vlan" "vlan" {
      + device = "xeac-cat9kv-uadp-1"
      + id     = (known after apply)
      + name   = 100
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "lji9bl2Xd/LkrANfXIu+tgG2rlGtbeSRBwK0x22X/GY=" -> (known after apply)
      ~ content_base64sha512 = "GfgMBWjE8EW3645ykflOcIDIExnz8aK9q8Lm3tVyH5+MUKjIQ5nm8ioid/nfTr288OAu8bCz+rmppRiFkLyGcQ==" -> (known after apply)
      ~ content_md5          = "49abf123f5ab6bcbdfa09b7c6d0b66fb" -> (known after apply)
      ~ content_sha1         = "9871970642a22c0b80459e7e4a9aebbdba283e64" -> (known after apply)
      ~ content_sha256       = "9638bd6e5d9777f2e4ac035f5c8bbeb601b6ae51ad6de4910702b4c76d97fc66" -> (known after apply)
      ~ content_sha512       = "19f80c0568c4f045b7eb8e7291f94e7080c81319f3f1a2bdabc2e6ded5721f9f8c50a8c84399e6f22a2277f9df4ebdbcf0e02ef1b0b3fab9a9a5188590bc8671" -> (known after apply)
      ~ id                   = "9871970642a22c0b80459e7e4a9aebbdba283e64" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=9871970642a22c0b80459e7e4a9aebbdba283e64]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=c05debfda4e491b1f432581623e96aeddf9bcdd2]
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Creating...
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Creation complete after 0s [id=Cisco-IOS-XE-native:native/interface/Vlan=100]
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
➜  nac-testing git:(main) ✗ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=c05debfda4e491b1f432581623e96aeddf9bcdd2]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Vlan=100]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
│
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

</details>

### Port-channel interface

<details>
<summary>Port-channel interface evidence</summary>

Data model:

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      url: https://192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        interfaces:
          port_channels:
            - id: 1
```

`terraform apply` output:

```text
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=c05debfda4e491b1f432581623e96aeddf9bcdd2]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Vlan=100]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_interface_port_channel.port_channel["xeac-cat9kv-uadp-1/Port-channel1"] will be created
  + resource "iosxe_interface_port_channel" "port_channel" {
      + device = "xeac-cat9kv-uadp-1"
      + id     = (known after apply)
      + name   = 1
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "O/W9OwhYGjZkVf/2iSDvkUQ40dQjCsyABTYMonRtjjo=" -> (known after apply)
      ~ content_base64sha512 = "1lppwkw+nIOdMoi8EU2rR6SZzOmEPCRtzAhNIk58XzCRCRyqPmjBF/2yrqXVvwgNqvAxrMxWG1PNs8E+GmW90Q==" -> (known after apply)
      ~ content_md5          = "d9904fb814f976220c13ab1c115e3dad" -> (known after apply)
      ~ content_sha1         = "c05debfda4e491b1f432581623e96aeddf9bcdd2" -> (known after apply)
      ~ content_sha256       = "3bf5bd3b08581a366455fff68920ef914438d1d4230acc8005360ca2746d8e3a" -> (known after apply)
      ~ content_sha512       = "d65a69c24c3e9c839d3288bc114dab47a499cce9843c246dcc084d224e7c5f3091091caa3e68c117fdb2aea5d5bf080daaf031accc561b53cdb3c13e1a65bdd1" -> (known after apply)
      ~ id                   = "c05debfda4e491b1f432581623e96aeddf9bcdd2" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=c05debfda4e491b1f432581623e96aeddf9bcdd2]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=141a1d32c3cbfcd20aae195906c9d6b5d8f76f0f]
module.iosxe.iosxe_interface_port_channel.port_channel["xeac-cat9kv-uadp-1/Port-channel1"]: Creating...
module.iosxe.iosxe_interface_port_channel.port_channel["xeac-cat9kv-uadp-1/Port-channel1"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
➜  nac-testing git:(main) ✗ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=141a1d32c3cbfcd20aae195906c9d6b5d8f76f0f]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Vlan=100]
module.iosxe.iosxe_interface_port_channel.port_channel["xeac-cat9kv-uadp-1/Port-channel1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
│
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

</details>

### Port-channel subinterface

<details>
<summary>Port-channel subinterface evidence</summary>

Data model:

(Note that the port-channel interface was created as part of a previous `terraform apply` run.)

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      url: https://192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        interfaces:
          port_channels:
            - id: 1
              switchport:
                enable: false
              subinterfaces:
                - id: "1.100"

```

`terraform apply` output:

```text
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=116762ce6590b54073e3b34d815ffcc71ca5604a]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Vlan=100]
module.iosxe.iosxe_interface_port_channel.port_channel["xeac-cat9kv-uadp-1/Port-channel1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_interface_port_channel_subinterface.port_channel_subinterface["xeac-cat9kv-uadp-1/Port-channel1.100"] will be created
  + resource "iosxe_interface_port_channel_subinterface" "port_channel_subinterface" {
      + device = "xeac-cat9kv-uadp-1"
      + id     = (known after apply)
      + name   = "1.100"
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "H1Y9R5ZfAnH5xKV8udqc43p1ZzEhE6aj7Aby58pTgCw=" -> (known after apply)
      ~ content_base64sha512 = "pp1DA07xqUDAuOYIDEziFQ0aZZeFaMNDE66WasOtKrxED1LuCiLL4jxo0CLuwudmiawjoxwRaj3/Fv+pHPrxCQ==" -> (known after apply)
      ~ content_md5          = "792282110c2a44481c237ac24d389a4f" -> (known after apply)
      ~ content_sha1         = "116762ce6590b54073e3b34d815ffcc71ca5604a" -> (known after apply)
      ~ content_sha256       = "1f563d47965f0271f9c4a57cb9da9ce37a7567312113a6a3ec06f2e7ca53802c" -> (known after apply)
      ~ content_sha512       = "a69d43034ef1a940c0b8e6080c4ce2150d1a65978568c34313ae966ac3ad2abc440f52ee0a22cbe23c68d022eec2e76689ac23a31c116a3dff16ffa91cfaf109" -> (known after apply)
      ~ id                   = "116762ce6590b54073e3b34d815ffcc71ca5604a" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=116762ce6590b54073e3b34d815ffcc71ca5604a]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=d1be20e66b8667462c01c3e7c6c76fb36e6b31a9]
module.iosxe.iosxe_interface_port_channel_subinterface.port_channel_subinterface["xeac-cat9kv-uadp-1/Port-channel1.100"]: Creating...
module.iosxe.iosxe_interface_port_channel_subinterface.port_channel_subinterface["xeac-cat9kv-uadp-1/Port-channel1.100"]: Creation complete after 0s [id=Cisco-IOS-XE-native:native/interface/Port-channel-subinterface/Port-channel=1.100]
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
╵

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
➜  nac-testing git:(main) ✗ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the
│ state to become incompatible with published releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=ba34e0d1675cc787c1181b1773e78e902e37b489]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=d1be20e66b8667462c01c3e7c6c76fb36e6b31a9]
module.iosxe.iosxe_interface_port_channel.port_channel["xeac-cat9kv-uadp-1/Port-channel1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]
module.iosxe.iosxe_interface_loopback.loopback["xeac-cat9kv-uadp-1/Loopback100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Loopback=100]
module.iosxe.iosxe_interface_port_channel_subinterface.port_channel_subinterface["xeac-cat9kv-uadp-1/Port-channel1.100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Port-channel-subinterface/Port-channel=1.100]
module.iosxe.iosxe_interface_vlan.vlan["xeac-cat9kv-uadp-1/Vlan100"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Vlan=100]
module.iosxe.iosxe_interface_ethernet.ethernet["xeac-cat9kv-uadp-1/GigabitEthernet1/0/3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/GigabitEthernet=1%2F0%2F3]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-1"]: Refreshing state... [id=Cisco-IOS-XE-native:native]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.
╷
│ Warning: Attribute Deprecated
│
│   with module.iosxe.provider["registry.terraform.io/ciscodevnet/iosxe"],
│   on ../terraform-iosxe-nac-iosxe/main.tf line 26, in provider "iosxe":
│   26: provider "iosxe" {
│
│ Use 'host' attribute instead
│
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

</details>
