### PR TITLE
fix(bgp): correct update_source variable name in bgp_neighbor resource

### DIFF
--- a/iosxe_bgp.tf
+++ b/iosxe_bgp.tf
@@ -129,7 +129,7 @@ resource "iosxe_bgp_neighbor" "bgp_neighbor" {
   timers_holdtime                           = each.value.timers_holdtime
   timers_minimum_neighbor_hold              = each.value.timers_minimum_neighbor_hold
   ttl_security_hops                         = each.value.ttl_security_hops
-  update_source_interface_loopback          = each.value.update_source_loopback
+  update_source_interface_loopback          = each.value.update_source_interface_loopback
   ebgp_multihop                             = each.value.ebgp_multihop
   ebgp_multihop_max_hop                     = each.value.ebgp_multihop_max_hop
   inherit_peer_session                      = each.value.inherit_peer_session


### PR DESCRIPTION
## Summary
- Fix variable name mismatch in `iosxe_bgp_neighbor` resource where `update_source_interface_loopback` was incorrectly referencing `each.value.update_source_loopback` instead of `each.value.update_source_interface_loopback`

## Root Cause
This bug was introduced in PR #97 (Add Multicast Advertise Support) and causes terraform plan/apply failures when BGP neighbor update-source configuration is used.

## Test plan
- [ ] Verify terraform plan succeeds with BGP neighbor configurations using `update_source_interface_type: Loopback`
- [ ] Verify nac-iosxe CI pipeline passes (unblocks PR #595)