### PR TITLE
[IS-IS] Fix: Add ip_router_isis attribute to enable IS-IS on loopback interfaces

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -563,6 +563,7 @@ locals {
         ipv6_pim_bsr_border                     = try(int.ipv6.pim.bsr_border, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv6.pim.bsr_border, null)
         ipv6_pim_dr_priority                    = try(int.ipv6.pim.dr_priority, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv6.pim.dr_priority, null)
         isis                                    = try(int.isis, null) != null ? true : false
+        isis_area_tag                           = try(int.isis.area_tag, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.isis.area_tag, null)
         isis_ipv4_metric_levels = try(length(int.isis.ipv4_metric_levels) == 0, true) ? null : [for level in int.isis.ipv4_metric_levels : {
           level = try(level.level, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.isis.ipv4_metric_levels.level, null)
           value = try(level.value, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.isis.ipv4_metric_levels.value, null)
@@ -597,6 +598,7 @@ resource "iosxe_interface_loopback" "loopback" {
   ipv6_mtu                        = each.value.ipv6_mtu
   ipv6_nd_ra_suppress_all         = each.value.ipv6_nd_ra_suppress_all
   arp_timeout                     = each.value.arp_timeout
+  ip_router_isis                  = each.value.isis_area_tag
 
   depends_on = [
     iosxe_vrf.vrf,


### PR DESCRIPTION
## Related Issue(s)

Fixes bug discovered in Schema PR netascode/nac-iosxe#607

**Depends on:** None (standalone bug fix)

## Problem Statement

PR #104 successfully implemented IS-IS support for the module, but was missing a **critical prerequisite attribute**. The `iosxe_interface_loopback` resource did not set the `ip_router_isis` attribute, which is a **mandatory prerequisite** for the `iosxe_interface_isis` resource (interface metrics) to function.

### Impact

This bug caused CI failures in Schema PR #607 with the following symptoms:
- `iosxe_interface_isis` resource failed with 404 errors
- Interface metrics returned empty
- IS-IS configuration workflow broken end-to-end

### Root Cause

During original Epic #506 testing (PR #104), the `ip router isis` command was applied **manually via CLI** during provider testing, which masked this module bug during end-to-end testing. The module never actually set this attribute, but testing "passed" because the manual CLI command satisfied the prerequisite.

Evidence from original testing notes:
```bash
# Enable IS-IS on the interface (ip router isis)
# Note: This may need to be done manually via CLI if no resource exists yet
# Manual CLI: interface Loopback506
#            ip router isis EPIC506-TEST
```

## Proposed Changes

This PR adds the missing `ip_router_isis` attribute to properly enable IS-IS on loopback interfaces.

### Code Changes

**File:** `iosxe_interfaces.tf`

**1. Add `isis_area_tag` local variable (line 521):**
```terraform
isis_area_tag = try(int.isis.area_tag, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.isis.area_tag, null)
```

**2. Add `ip_router_isis` attribute to resource (line 556):**
```terraform
resource "iosxe_interface_loopback" "loopback" {
  ...
  arp_timeout    = each.value.arp_timeout
  ip_router_isis = each.value.isis_area_tag  # ADDED
  
  depends_on = [
    ...
  ]
}
```

### How It Works

1. User specifies `area_tag` in YAML (added in Schema PR #607):
   ```yaml
   interfaces:
     loopbacks:
       - id: 100
         isis:
           area_tag: TEST  # Links to IS-IS process
           ipv4_metric_levels:
             - level: level-1
               value: 100
   ```

2. Module extracts `isis_area_tag` from YAML via local variable

3. Module sets `ip_router_isis = each.value.isis_area_tag` on loopback resource

4. Provider configures: `interface Loopback100` → `ip router isis TEST`

5. Provider can now configure metrics via `iosxe_interface_isis` resource (prerequisite satisfied)

## Testing

### E2E Testing on Real Hardware

 **All tests passed** on device 10.81.239.57 (Cat9k/Cat8k)

**Test Results:**
-  Terraform Init - Successful
-  Terraform Plan - Shows `ip_router_isis = "EPIC506-TEST"`
-  Terraform Apply - All 3 resources created (isis process, loopback, metrics)
-  Device Verification - `ip router isis EPIC506-TEST` present on interface
-  IS-IS Metrics - Level-1 (100) and Level-2 (50) configured correctly
-  Idempotency - No changes detected on second plan
-  Terraform Destroy - Clean removal of all resources

**Device Configuration Verified:**
```
interface Loopback506
 ip address 192.0.2.100 255.255.255.255
 ip router isis EPIC506-TEST      ← THE FIX WORKS!
 isis metric 100 level-1
 isis metric 50 level-2
```

### Test Coverage

| Test | Status | Notes |
|------|--------|-------|
| Module Local Variable |  PASS | `isis_area_tag` extracted from YAML |
| Resource Attribute |  PASS | `ip_router_isis` set on loopback |
| Terraform Plan |  PASS | 3 resources to add |
| Terraform Apply |  PASS | All resources created |
| Device Config |  PASS | `ip router isis` command present |
| ISIS Metrics |  PASS | Level-1 and Level-2 configured |
| Idempotency |  PASS | No drift detected |
| Destroy |  PASS | Clean removal |

**Overall:** 8/8 tests passed

## Files Changed

**Manual Changes:**
- `iosxe_interfaces.tf` - Added `isis_area_tag` local variable (1 line)
- `iosxe_interfaces.tf` - Added `ip_router_isis` attribute (1 line)

**Total:** 1 file changed, 2 lines added

## NAC YAML to CLI Mapping

**User writes in YAML:**
```yaml
interfaces:
  loopbacks:
    - id: 100
      isis:
        area_tag: TEST
        ipv4_metric_levels:
          - level: level-1
            value: 100
```

**Device gets:**
```
interface Loopback100
 ip router isis TEST
 isis metric 100 level-1
```

## Cisco IOS-XE Version

**Minimum Version:** IOS-XE 17.12.1

**Compatibility:**
-  IOS-XE 17.12.1 and later
-  IOS-XE 17.15.1 and later

No version-specific restrictions required.

## External Repo Link

**Related PRs:**
- Schema PR: https://wwwin-github.cisco.com/netascode/nac-iosxe/pull/607 (depends on this fix)
- Original Module PR: https://github.com/netascode/terraform-iosxe-nac-iosxe/pull/104 (merged)

## Checklist

- [x] Latest commit is rebased from `main`
- [x] Code follows module patterns and conventions
- [x] Changes tested on real hardware (E2E validated)
- [x] Backwards compatible (no breaking changes)
- [x] Idempotency verified
- [x] Device configuration verified via CLI
- [x] Git commit message follows team standards
- [x] Documentation updated (Schema PR #607 includes docs)
- [x] Related PRs linked

## Expected CI Behavior

 **Expected to PASS**

This is a minimal, surgical fix (2 lines) that:
- Follows existing module patterns
- Uses standard `try()` pattern for optional attributes
- No new resources or complex logic
- Already E2E tested successfully on real hardware

## Impact Assessment

**Breaking Changes:** None

**Backwards Compatibility:** Fully compatible
- Existing configurations without `area_tag` will work as before (attribute will be `null`)
- New configurations with `area_tag` will enable IS-IS on interfaces
- No changes to existing resource behavior

**Dependencies:**
- Schema PR #607 adds the `area_tag` schema field
- This module fix allows that schema field to be used
- Both can be merged independently (graceful degradation)

## Additional Notes

### Lessons Learned

This bug highlights the importance of:
1. **No manual CLI steps in testing** - Manual workarounds mask automation bugs
2. **Provider prerequisites must be in module** - Check `test_prerequisites` in provider YAML
3. **Full E2E automation** - Test complete path: YAML → Schema → Module → Provider → Device

### Documentation Updates

The following Master Guide updates are recommended (separate effort):
- **PHASE-5-MODULE-IMPLEMENTATION.md:** Add checkpoint to verify provider prerequisites
- **PHASE-6-E2E-TESTING.md:** Emphasize fully automated testing (no manual steps)

## Reviewer Notes

**Review Focus Areas:**
1.  Correct placement of `isis_area_tag` in locals (line 521)
2.  Correct attribute name `ip_router_isis` (matches provider resource)
3.  Proper use of `try()` pattern with defaults
4.  No impact on other interface types (Ethernet, VLAN, etc.)

**Commit to Review:**
- Commit `5ad418f`: "fix(isis): Add ip_router_isis attribute to enable IS-IS on loopback interfaces"

This is a critical bug fix that unblocks Schema PR #607 and completes the IS-IS workflow.

