### PR TITLE
fix: resolve EEM string trim/first action mapping

### DIFF
--- a/iosxe_eem.tf
+++ b/iosxe_eem.tf
@@ -107,9 +107,9 @@ locals {
                 # String trim action - trims whitespace from string
                 string_trim = try(action.string_trim, local.defaults.iosxe.configuration.eem.applets.actions.string_trim, null)
 
-                # String first action - finds first occurrence of substring
-                string_first_string_op_1 = try(action.string_first.operand1, local.defaults.iosxe.configuration.eem.applets.actions.string_first.operand1, null)
-                string_first_string_op_2 = try(action.string_first.operand2, local.defaults.iosxe.configuration.eem.applets.actions.string_first.operand2, null)
+                # String first action - finds first occurrence of substring in string
+                string_first_string_op_1 = try(action.string_first.string, local.defaults.iosxe.configuration.eem.applets.actions.string_first.string, null)
+                string_first_string_op_2 = try(action.string_first.substring, local.defaults.iosxe.configuration.eem.applets.actions.string_first.substring, null)
               }
             ]
           }

--- a/iosxe_eem.tf
+++ b/iosxe_eem.tf
@@ -104,9 +104,12 @@ locals {
                 # Wait action
                 wait = try(action.wait, local.defaults.iosxe.configuration.eem.applets.actions.wait, null)
 
-                # String trim action - uses string/first container, not deprecated string/trim leaf
-                string_first_string_op_1 = try(action.string_trim.input, local.defaults.iosxe.configuration.eem.applets.actions.string_trim.input, null)
-                string_first_string_op_2 = try(action.string_trim.output_variable, local.defaults.iosxe.configuration.eem.applets.actions.string_trim.output_variable, null)
+                # String trim action - trims whitespace from string
+                string_trim = try(action.string_trim, local.defaults.iosxe.configuration.eem.applets.actions.string_trim, null)
+
+                # String first action - finds first occurrence of substring
+                string_first_string_op_1 = try(action.string_first.operand1, local.defaults.iosxe.configuration.eem.applets.actions.string_first.operand1, null)
+                string_first_string_op_2 = try(action.string_first.operand2, local.defaults.iosxe.configuration.eem.applets.actions.string_first.operand2, null)
               }
             ]
           }

--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -348,8 +348,7 @@ resource "iosxe_interface_ethernet" "ethernet" {
     iosxe_vrf.vrf,
     iosxe_access_list_standard.access_list_standard,
     iosxe_access_list_extended.access_list_extended,
-    iosxe_policy_map.policy_map,
-    iosxe_evpn_ethernet_segment.evpn_ethernet_segment
+    iosxe_policy_map.policy_map
   ]
 }
 
@@ -1179,10 +1178,6 @@ resource "iosxe_interface_port_channel" "port_channel" {
   trust_device                     = each.value.trust_device
   negotiation_auto                 = each.value.negotiation_auto
   evpn_ethernet_segments           = each.value.evpn_ethernet_segments
-
-  depends_on = [
-    iosxe_evpn_ethernet_segment.evpn_ethernet_segment
-  ]
 }
 
 resource "iosxe_interface_switchport" "port_channel_switchport" {

--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -348,7 +348,8 @@ resource "iosxe_interface_ethernet" "ethernet" {
     iosxe_vrf.vrf,
     iosxe_access_list_standard.access_list_standard,
     iosxe_access_list_extended.access_list_extended,
-    iosxe_policy_map.policy_map
+    iosxe_policy_map.policy_map,
+    iosxe_evpn_ethernet_segment.evpn_ethernet_segment
   ]
 }
 
@@ -1178,6 +1179,10 @@ resource "iosxe_interface_port_channel" "port_channel" {
   trust_device                     = each.value.trust_device
   negotiation_auto                 = each.value.negotiation_auto
   evpn_ethernet_segments           = each.value.evpn_ethernet_segments
+
+  depends_on = [
+    iosxe_evpn_ethernet_segment.evpn_ethernet_segment
+  ]
 }
 
 resource "iosxe_interface_switchport" "port_channel_switchport" {


### PR DESCRIPTION
This PR resolves a silly error with EEM string actions. The `trim` element of the data model was incorrectly pointing to the `first` attribute in the provider. This PR resolves this issue and simultaneously adds support for the `first` EEM action as well.