### PR TITLE
[Routing] Add Protocol Purge Support in Terraform Module

### DIFF
--- a/iosxe_system.tf
+++ b/iosxe_system.tf
@@ -239,6 +239,9 @@ resource "iosxe_system" "system" {
   authentication_mac_move_permit            = try(local.device_config[each.value.name].system.authentication_mac_move_permit, local.defaults.iosxe.configuration.system.authentication_mac_move_permit, null)
   authentication_mac_move_deny_uncontrolled = try(local.device_config[each.value.name].system.authentication_mac_move_deny_uncontrolled, local.defaults.iosxe.configuration.system.authentication_mac_move_deny_uncontrolled, null)
 
+  # Routing Protocol Purge
+  ip_routing_protocol_purge_interface = try(local.device_config[each.value.name].system.ip_routing_protocol_purge_interface, local.defaults.iosxe.configuration.system.ip_routing_protocol_purge_interface, null)
+
   # Table-Map configurations for QoS value translation
   table_maps = try(length(local.device_config[each.value.name].system.table_maps) == 0, true) ? null : [
     for table_map in local.device_config[each.value.name].system.table_maps : {


### PR DESCRIPTION
# This PR extends the Terraform module to support IP routing protocol purge interface configurations.

## Overview

This enables users to control whether routing protocols automatically purge routes when an interface goes down.

## Changes

### Module Updates (`iosxe_system.tf`)
- Added `ip_routing_protocol_purge_interface` attribute to the `iosxe_system` resource
- Implements standard `try()` pattern with device config fallback to defaults
- Placed in new "Routing Protocol Purge" section for logical organization

## CLI Command Supported

```
ip routing protocol purge interface
```

## Usage Example

```yaml
iosxe:
  devices:
    - name: Router1
      configuration:
        system:
          hostname: Router1
          ip_routing: true
          ip_routing_protocol_purge_interface: true
```

## Testing

- [x] Pre-commit hooks passed
- [x] Terraform formatting validated
- [x] Integration testing with live devices

## Checklist

- [x] Module attribute added with proper try() pattern
- [x] Pre-commit hooks executed successfully
- [x] No breaking changes to existing functionality
- [x] Follows existing code patterns and conventions