### PR TITLE
[Spanning-Tree] Add Advanced Support in Terraform Module

### DIFF
--- a/iosxe_spanning_tree.tf
+++ b/iosxe_spanning_tree.tf
@@ -3,6 +3,7 @@ resource "iosxe_spanning_tree" "spanning_tree" {
   device   = each.value.name
 
   mode                       = try(local.device_config[each.value.name].spanning_tree.mode, local.defaults.iosxe.configuration.spanning_tree.mode, null)
+  logging                    = try(local.device_config[each.value.name].spanning_tree.logging, local.defaults.iosxe.configuration.spanning_tree.logging, null)
   loopguard_default          = try(local.device_config[each.value.name].spanning_tree.loopguard_default, local.defaults.iosxe.configuration.spanning_tree.loopguard_default, null)
   portfast_default           = try(local.device_config[each.value.name].spanning_tree.portfast_default, local.defaults.iosxe.configuration.spanning_tree.portfast_default, null)
   portfast_bpduguard_default = try(local.device_config[each.value.name].spanning_tree.portfast_bpduguard_default, local.defaults.iosxe.configuration.spanning_tree.portfast_bpduguard_default, null)
@@ -17,5 +18,10 @@ resource "iosxe_spanning_tree" "spanning_tree" {
       ),
       concat(range(1, 1025), range(1025, 2049), range(2049, 3073), range(3073, 4094))
     )
+  }]
+
+  vlans = try(length(local.device_config[each.value.name].spanning_tree.vlans) == 0, true) ? null : [for v in local.device_config[each.value.name].spanning_tree.vlans : {
+    id       = try(tostring(v.id), local.defaults.iosxe.configuration.spanning_tree.vlans.id, null)
+    priority = try(v.priority, local.defaults.iosxe.configuration.spanning_tree.vlans.priority, null)
   }]
 }


### PR DESCRIPTION
## Summary

This PR adds support for two new spanning-tree attributes in the Terraform module, enabling declarative configuration of STP logging and per-VLAN bridge priority through the Network as Code (NAC) data model.

## Schema mappings:

- spanning_tree.logging → logging
- spanning_tree.vlans[].id → vlans[].id
- spanning_tree.vlans[].priority → vlans[].priority

## Changes:

- Add logging attribute mapping to iosxe_spanning_tree.tf
- Add vlans block with id and priority attribute mappings to iosxe_spanning_tree.tf
- Support for both device-specific and default configuration values

This enables declarative configuration of:

- STP event logging for topology changes and root bridge elections
- Per-VLAN bridge priority in Rapid-PVST+ mode (valid values: 0-61440 in increments of 4096)

## Testing

Validated against Catalyst 9000v with full CRUD operations for logging and per-VLAN priority attributes.

Data model:

```yaml
iosxe:
  devices:
    - name: xeac-cat9kv-uadp-1
      host: 192.0.2.10
      configuration:
        system:
          hostname: xeac-cat9kv-uadp-1
        vlan:
          vlans:
            - id: 10
            - id: 20
            - id: 30
            - id: 100
        spanning_tree:
          mode: rapid-pvst
          logging: true
          loopguard_default: true
          portfast_default: true
          portfast_bpduguard_default: true
          vlans:
            - id: 10
              priority: 4096
            - id: 20
              priority: 8192
            - id: 30
              priority: 4096
```