### PR TITLE
fix: correct logging count attribute reference in data path

### DIFF
--- a/iosxe_logging.tf
+++ b/iosxe_logging.tf
@@ -19,7 +19,7 @@ resource "iosxe_logging" "logging" {
   file_min_size       = try(local.device_config[each.value.name].logging.file_min_size, local.defaults.iosxe.configuration.logging.file_min_size, null)
   file_severity       = try(local.device_config[each.value.name].logging.file_severity, local.defaults.iosxe.configuration.logging.file_severity, null)
   source_interface    = try("${try(local.device_config[each.value.name].logging.source_interface_type, local.defaults.iosxe.configuration.logging.source_interface_type)}${try(trimprefix(local.device_config[each.value.name].logging.source_interface_id, "$string "), local.defaults.iosxe.configuration.logging.source_interface_id)}", null)
-  logging_count       = try(local.device_config[each.value.name].logging.logging_count, local.defaults.iosxe.configuration.logging.logging_count, null)
+  logging_count       = try(local.device_config[each.value.name].logging.count, local.defaults.iosxe.configuration.logging.count, null)
   persistent_url      = try(local.device_config[each.value.name].logging.persistent_url, local.defaults.iosxe.configuration.logging.persistent_url, null)
   persistent_size     = try(local.device_config[each.value.name].logging.persistent_size, local.defaults.iosxe.configuration.logging.persistent_size, null)
   persistent_filesize = try(local.device_config[each.value.name].logging.persistent_filesize, local.defaults.iosxe.configuration.logging.persistent_filesize, null)


### PR DESCRIPTION
## Summary

Updates the Terraform module to reference the correct schema attribute name for logging count functionality.

## Changes

- **File**: `iosxe_logging.tf` (line 22)
- **Change**: Updated data path from `logging.logging_count` to `logging.count`
- **Reason**: Remove redundant prefix

### What Changed

**Before:**
```terraform
logging_count = try(local.device_config[each.value.name].logging.logging_count, ...)
```

**After:**
```terraform
logging_count = try(local.device_config[each.value.name].logging.count, ...)
```

## Testing

- ✅ Pre-commit hooks passed (terraform fmt, tflint, terraform-docs)
- ✅ All checks validated successfully