### PR TITLE
fix(interfaces): correct hold_queues logic to avoid empty list

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -287,7 +287,7 @@ locals {
             direction    = "out"
             queue_length = try(int.hold_queue_out, local.defaults.iosxe.devices.configuration.interfaces.ethernets.hold_queue_out, null)
           }] : []
-        ]) : []
+        ]) : null
         service_instances = try(length(int.service_instances) == 0, true) ? null : [for si in int.service_instances : {
           id                     = try(si.id, local.defaults.iosxe.devices.configuration.interfaces.ethernets.service_instances.id, null)
           ethernet               = try(si.type, local.defaults.iosxe.devices.configuration.interfaces.ethernets.service_instances.type, null) == "ethernet" ? true : null


### PR DESCRIPTION
### Issue

**Description**
The hold-queue configuration is added to the interfaces in the device, even if hold_queues defined in the data model.

**Expected Behavior**
hold-queue configuration should not be added to the interfaces.

**Actual Behavior**
TF provider is (incorrectly) adding this configuration to all interfaces:

```
interface GigabitEthernet6
 hold-queue 0 in
 hold-queue 0 out
```

### Solution

- Updated `hold_queues` calculation logic in `iosxe_interfaces.tf` for Ethernet interfaces.
- Changed the default fallback value from an empty list `[]` to `null`.
- This ensures that when no hold queues are defined, the Terraform provider receives a `null` value (which it ignores) rather than an empty block, resolving the validation error reported in the issue.

### Validation

Verified that `terraform plan` no longer includes hold-queue by default




