### PR TITLE
fix: add depends_on for IPsec profile in tunnel resource

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -2199,7 +2199,8 @@ resource "iosxe_interface_tunnel" "tunnel" {
   depends_on = [
     iosxe_vrf.vrf,
     iosxe_access_list_standard.access_list_standard,
-    iosxe_access_list_extended.access_list_extended
+    iosxe_access_list_extended.access_list_extended,
+    iosxe_crypto_ipsec_profile.crypto_ipsec_profile
   ]
 }
 


### PR DESCRIPTION
## Summary
- Adds `iosxe_crypto_ipsec_profile.crypto_ipsec_profile` to `depends_on` for tunnel resource
- Fixes race condition where tunnel creation can fail if IPsec profile isn't created first

## Problem

When deploying a tunnel interface with IPsec protection, Terraform may attempt to create both resources in parallel:

```
module.iosxe.iosxe_crypto_ipsec_profile.crypto_ipsec_profile["xeac-cat8kv-1/IPSEC_PROFILE_1108"]: Creating...
module.iosxe.iosxe_interface_tunnel.tunnel["xeac-cat8kv-1/Tunnel1108"]: Creating...
```

This can result in:
```
Error: It seems IPSec profile doesn't exist or attempting to remove when referred by tunnel config
```

## Solution

After adding the `depends_on`, Terraform correctly sequences the creation:

```
module.iosxe.iosxe_crypto_ipsec_profile.crypto_ipsec_profile["xeac-cat8kv-1/IPSEC_PROFILE_1108"]: Creating...
module.iosxe.iosxe_crypto_ipsec_profile.crypto_ipsec_profile["xeac-cat8kv-1/IPSEC_PROFILE_1108"]: Creation complete after 1s
module.iosxe.iosxe_interface_tunnel.tunnel["xeac-cat8kv-1/Tunnel1108"]: Creating...
module.iosxe.iosxe_interface_tunnel.tunnel["xeac-cat8kv-1/Tunnel1108"]: Creation complete after 3s
```

## Sample Data Model

```yaml
iosxe:
  devices:
    - name: router1
      configuration:
        crypto:
          ipsec_profiles:
            - name: IPSEC_PROFILE_1108
              set_transform_set: ["TRANSFORM_SET_1108"]
              set_ikev2_profile: IKEV2_PROFILE_1108
        interfaces:
          tunnels:
            - name: 1108
              tunnel_destination_ipv4: 198.51.100.1
              tunnel_source: GigabitEthernet1
              tunnel_mode_ipsec_ipv4: true
              tunnel_protection_ipsec_profile: IPSEC_PROFILE_1108
```

## Test plan
- [x] Verified dependency graph shows correct ordering
- [x] Confirmed tunnel waits for IPsec profile before creation
- [x] Validated fix has no impact on tunnels without IPsec profiles

Fixes netascode/nac-iosxe#1108

---
🤖 Generated with [Claude Code](https://claude.ai/code)