### PR TITLE
fix: correct BFD multi-hop meticulous SHA-1 attribute mapping

### DIFF
--- a/iosxe_bfd.tf
+++ b/iosxe_bfd.tf
@@ -51,29 +51,29 @@ locals {
   bfd_template_multi_hop = flatten([
     for device in local.devices : [
       for template in try(local.device_config[device.name].bfd.multi_hop_templates, []) : {
-        key                                     = format("%s/%s", device.name, try(template.name, null))
-        device                                  = device.name
-        name                                    = try(template.name, local.defaults.iosxe.configuration.bfd.multi_hop_templates.name, null)
-        authentication_md5_keychain             = try(template.authentication_md5_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_md5_keychain, null)
-        authentication_meticulous_md5_keychain  = try(template.authentication_meticulous_md5_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_meticulous_md5_keychain, null)
-        authentication_meticulous_sha_1keychain = try(template.authentication_meticulous_sha_1keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_meticulous_sha_1keychain, null)
-        authentication_sha_1_keychain           = try(template.authentication_sha_1_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_sha_1_keychain, null)
-        interval_milliseconds_both              = try(template.interval_milliseconds_both, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_both, null)
-        interval_milliseconds_min_tx            = try(template.interval_milliseconds_min_tx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_min_tx, null)
-        interval_milliseconds_min_rx            = try(template.interval_milliseconds_min_rx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_min_rx, null)
-        interval_milliseconds_multiplier        = try(template.interval_milliseconds_multiplier, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_multiplier, null)
-        interval_microseconds_both              = try(template.interval_microseconds_both, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_both, null)
-        interval_microseconds_min_tx            = try(template.interval_microseconds_min_tx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_min_tx, null)
-        interval_microseconds_min_rx            = try(template.interval_microseconds_min_rx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_min_rx, null)
-        interval_microseconds_multiplier        = try(template.interval_microseconds_multiplier, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_multiplier, null)
-        interval_microseconds                   = try(template.interval_microseconds, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds, null)
-        echo                                    = try(template.echo, local.defaults.iosxe.configuration.bfd.multi_hop_templates.echo, null)
-        dampening_half_time                     = try(template.dampening_half_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_half_time, null)
-        dampening_unsuppress_time               = try(template.dampening_unsuppress_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_unsuppress_time, null)
-        dampening_suppress_time                 = try(template.dampening_suppress_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_suppress_time, null)
-        dampening_max_suppressing_time          = try(template.dampening_max_suppressing_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_max_suppressing_time, null)
-        dampening_threshold                     = try(template.dampening_threshold, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_threshold, null)
-        dampening_down_monitoring               = try(template.dampening_down_monitoring, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_down_monitoring, null)
+        key                                      = format("%s/%s", device.name, try(template.name, null))
+        device                                   = device.name
+        name                                     = try(template.name, local.defaults.iosxe.configuration.bfd.multi_hop_templates.name, null)
+        authentication_md5_keychain              = try(template.authentication_md5_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_md5_keychain, null)
+        authentication_meticulous_md5_keychain   = try(template.authentication_meticulous_md5_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_meticulous_md5_keychain, null)
+        authentication_meticulous_sha_1_keychain = try(template.authentication_meticulous_sha1_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_meticulous_sha1_keychain, null)
+        authentication_sha_1_keychain            = try(template.authentication_sha_1_keychain, local.defaults.iosxe.configuration.bfd.multi_hop_templates.authentication_sha_1_keychain, null)
+        interval_milliseconds_both               = try(template.interval_milliseconds_both, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_both, null)
+        interval_milliseconds_min_tx             = try(template.interval_milliseconds_min_tx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_min_tx, null)
+        interval_milliseconds_min_rx             = try(template.interval_milliseconds_min_rx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_min_rx, null)
+        interval_milliseconds_multiplier         = try(template.interval_milliseconds_multiplier, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_milliseconds_multiplier, null)
+        interval_microseconds_both               = try(template.interval_microseconds_both, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_both, null)
+        interval_microseconds_min_tx             = try(template.interval_microseconds_min_tx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_min_tx, null)
+        interval_microseconds_min_rx             = try(template.interval_microseconds_min_rx, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_min_rx, null)
+        interval_microseconds_multiplier         = try(template.interval_microseconds_multiplier, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds_multiplier, null)
+        interval_microseconds                    = try(template.interval_microseconds, local.defaults.iosxe.configuration.bfd.multi_hop_templates.interval_microseconds, null)
+        echo                                     = try(template.echo, local.defaults.iosxe.configuration.bfd.multi_hop_templates.echo, null)
+        dampening_half_time                      = try(template.dampening_half_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_half_time, null)
+        dampening_unsuppress_time                = try(template.dampening_unsuppress_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_unsuppress_time, null)
+        dampening_suppress_time                  = try(template.dampening_suppress_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_suppress_time, null)
+        dampening_max_suppressing_time           = try(template.dampening_max_suppressing_time, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_max_suppressing_time, null)
+        dampening_threshold                      = try(template.dampening_threshold, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_threshold, null)
+        dampening_down_monitoring                = try(template.dampening_down_monitoring, local.defaults.iosxe.configuration.bfd.multi_hop_templates.dampening_down_monitoring, null)
       }
     ]
   ])
@@ -83,27 +83,27 @@ resource "iosxe_bfd_template_multi_hop" "bfd_template_multi_hop" {
   for_each = { for e in local.bfd_template_multi_hop : e.key => e }
   device   = each.value.device
 
-  name                                    = each.value.name
-  authentication_md5_keychain             = each.value.authentication_md5_keychain
-  authentication_meticulous_md5_keychain  = each.value.authentication_meticulous_md5_keychain
-  authentication_meticulous_sha_1keychain = each.value.authentication_meticulous_sha_1keychain
-  authentication_sha_1_keychain           = each.value.authentication_sha_1_keychain
-  interval_milliseconds_both              = each.value.interval_milliseconds_both
-  interval_milliseconds_min_tx            = each.value.interval_milliseconds_min_tx
-  interval_milliseconds_min_rx            = each.value.interval_milliseconds_min_rx
-  interval_milliseconds_multiplier        = each.value.interval_milliseconds_multiplier
-  interval_microseconds_both              = each.value.interval_microseconds_both
-  interval_microseconds_min_tx            = each.value.interval_microseconds_min_tx
-  interval_microseconds_min_rx            = each.value.interval_microseconds_min_rx
-  interval_microseconds_multiplier        = each.value.interval_microseconds_multiplier
-  interval_microseconds                   = each.value.interval_microseconds
-  echo                                    = each.value.echo
-  dampening_half_time                     = each.value.dampening_half_time
-  dampening_unsuppress_time               = each.value.dampening_unsuppress_time
-  dampening_suppress_time                 = each.value.dampening_suppress_time
-  dampening_max_suppressing_time          = each.value.dampening_max_suppressing_time
-  dampening_threshold                     = each.value.dampening_threshold
-  dampening_down_monitoring               = each.value.dampening_down_monitoring
+  name                                     = each.value.name
+  authentication_md5_keychain              = each.value.authentication_md5_keychain
+  authentication_meticulous_md5_keychain   = each.value.authentication_meticulous_md5_keychain
+  authentication_meticulous_sha_1_keychain = each.value.authentication_meticulous_sha_1_keychain
+  authentication_sha_1_keychain            = each.value.authentication_sha_1_keychain
+  interval_milliseconds_both               = each.value.interval_milliseconds_both
+  interval_milliseconds_min_tx             = each.value.interval_milliseconds_min_tx
+  interval_milliseconds_min_rx             = each.value.interval_milliseconds_min_rx
+  interval_milliseconds_multiplier         = each.value.interval_milliseconds_multiplier
+  interval_microseconds_both               = each.value.interval_microseconds_both
+  interval_microseconds_min_tx             = each.value.interval_microseconds_min_tx
+  interval_microseconds_min_rx             = each.value.interval_microseconds_min_rx
+  interval_microseconds_multiplier         = each.value.interval_microseconds_multiplier
+  interval_microseconds                    = each.value.interval_microseconds
+  echo                                     = each.value.echo
+  dampening_half_time                      = each.value.dampening_half_time
+  dampening_unsuppress_time                = each.value.dampening_unsuppress_time
+  dampening_suppress_time                  = each.value.dampening_suppress_time
+  dampening_max_suppressing_time           = each.value.dampening_max_suppressing_time
+  dampening_threshold                      = each.value.dampening_threshold
+  dampening_down_monitoring                = each.value.dampening_down_monitoring
 }
 
 resource "iosxe_bfd" "bfd" {


### PR DESCRIPTION
## Summary

Updates the BFD multi-hop template module to correctly map the schema attribute name to the updated provider attribute name for meticulous SHA-1 authentication.

## Problem

The provider fixed an xpath bug and standardized the attribute name:
- **Schema**: `authentication_meticulous_sha1_keychain`
- **Provider (old, broken)**: `authentication_meticulous_sha_1keychain`
- **Provider (new, fixed)**: `authentication_meticulous_sha_1_keychain`

The module needed to be updated to translate between the schema name and the new provider name.

## Change

Updated `iosxe_bfd.tf` to map from the schema attribute to the provider attribute:

```hcl
# Before (broken - referenced non-existent provider attribute)
authentication_meticulous_sha_1_keychain = try(template.authentication_meticulous_sha_1_keychain, ...)

# After (fixed - maps schema name to provider name)
authentication_meticulous_sha_1_keychain = try(template.authentication_meticulous_sha1_keychain, ...)
```

## Dependencies

Requires provider fix: CiscoDevNet/terraform-provider-iosxe#433

## Testing

Tested with the following data model:

```yaml
bfd:
  multi_hop_templates:
    - name: issue-1097-test
      interval_milliseconds_both: 250
      interval_milliseconds_multiplier: 4
      authentication_meticulous_sha1_keychain: test-sha1-keychain
```

Verified on:

| Platform | Protocol | Result |
|----------|----------|--------|
| Cat8kv (17.15) | RESTCONF | ✅ Pass |
| Cat8kv (17.12) | NETCONF | ✅ Pass |
| Cat9kv (17.15) | NETCONF | ✅ Pass |

Related: netascode/nac-iosxe#1097

---

🤖 Generated with [Claude Code](https://claude.ai/code)