### PR TITLE
[BUG] fixed eui_64 attribute to match schema, and provider resource definition

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -68,7 +68,7 @@ locals {
         ipv6_enable                = try(int.ipv6.enable, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv6.enable, null)
         ipv6_addresses = try(length(int.ipv6.addresses) == 0, true) ? null : [for addr in int.ipv6.addresses : {
           prefix = try(addr.prefix, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv6.addresses.prefix, null)
-          eui64  = try(addr.eui64, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv6.addresses.eui64, null)
+          eui_64 = try(addr.eui_64, local.defaults.iosxe.devices.configuration.interfaces.ethernets.ipv6.addresses.eui_64, null)
         }]
         ipv6_link_local_addresses = try(length(int.ipv6.link_local_addresses) == 0, true) ? null : [for addr in int.ipv6.link_local_addresses : {
           address    = addr
@@ -865,7 +865,7 @@ locals {
         ipv6_enable                = try(int.ipv6.enable, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv6.enable, null)
         ipv6_addresses = try(length(int.ipv6.addresses) == 0, true) ? null : [for addr in int.ipv6.addresses : {
           prefix = try(addr.prefix, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv6.addresses.prefix, null)
-          eui64  = try(addr.eui64, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv6.addresses.eui64, null)
+          eui_64 = try(addr.eui_64, local.defaults.iosxe.devices.configuration.interfaces.loopbacks.ipv6.addresses.eui_64, null)
         }]
         ipv6_link_local_addresses = try(length(int.ipv6.link_local_addresses) == 0, true) ? null : [for addr in int.ipv6.link_local_addresses : {
           address    = addr
@@ -1128,7 +1128,7 @@ locals {
         ipv6_enable                = try(int.ipv6.enable, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv6.enable, null)
         ipv6_addresses = try(length(int.ipv6.addresses) == 0, true) ? null : [for addr in int.ipv6.addresses : {
           prefix = try(addr.prefix, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv6.addresses.prefix, null)
-          eui64  = try(addr.eui64, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv6.addresses.eui64, null)
+          eui_64 = try(addr.eui_64, local.defaults.iosxe.devices.configuration.interfaces.vlans.ipv6.addresses.eui_64, null)
         }]
         ipv6_link_local_addresses = try(length(int.ipv6.link_local_addresses) == 0, true) ? null : [for addr in int.ipv6.link_local_addresses : {
           address    = addr


### PR DESCRIPTION
Provider resource for this object is named "eui_64".  Fix to this attribute in Terraform module required for settings applied to this attribute to be picked up.