### PR TITLE
fix(aaa): normalize accounting.connections to never set default leaf

### DIFF
--- a/iosxe_aaa.tf
+++ b/iosxe_aaa.tf
@@ -86,8 +86,9 @@ resource "iosxe_aaa_accounting" "aaa_accounting" {
     group4_group    = try(e.groups[3], local.defaults.iosxe.configuration.aaa.accounting.commands.groups[3], null)
   }]
   connections = try(length(local.device_config[each.value.name].aaa.accounting.connections) == 0, true) ? null : [for e in local.device_config[each.value.name].aaa.accounting.connections : {
-    name                 = try(e.name, local.defaults.iosxe.configuration.aaa.accounting.connections.name, null)
-    default              = try(e.default, local.defaults.iosxe.configuration.aaa.accounting.connections.default, null)
+    name = try(e.name, local.defaults.iosxe.configuration.aaa.accounting.connections.name, null)
+    # Note: The 'default' leaf should NOT be set for connection accounting - use name: "default" instead
+    default              = null
     none                 = try(e.none, local.defaults.iosxe.configuration.aaa.accounting.connections.none, null)
     start_stop_broadcast = try(e.start_stop_broadcast, local.defaults.iosxe.configuration.aaa.accounting.connections.start_stop_broadcast, null)
     start_stop_logger    = try(e.start_stop_group_logger, local.defaults.iosxe.configuration.aaa.accounting.connections.start_stop_group_logger, null)


### PR DESCRIPTION
## Summary

- Normalize `aaa.accounting.connections` handling to never set the `default` leaf - users should use `name: "default"` instead

## Context

Investigation revealed that the IOS-XE YANG model has inconsistent handling of "default" across AAA accounting sections:

| Section | How "default" works |
|---------|---------------------|
| `connection` | Has a `leaf default { type empty; }` within list entries |
| `exec` | No default leaf - use `name: "default"` |
| `network` | No default leaf - "default" is an enum option for the `id` key |
| `dot1x` | Separate `container default` at the dot1x level |

The Terraform provider faithfully mirrors these YANG inconsistencies. However, for `accounting.connections`, setting the `default` leaf produces invalid CLI when combined with a name:

```
# Invalid - setting both name and default leaf
aaa accounting connection my-list default  ← Device rejects this

# Valid - using name: "default"
aaa accounting connection default none     ← Works correctly
```

## Changes

### `iosxe_aaa.tf`
- Set `default = null` for all connection entries
- The `default` leaf should never be set; users configure the default connection list by using `name: "default"`

## Sample Data Model

```yaml
aaa:
  new_model: true
  authentication:
    logins:
      - name: default
        methods:
          - local
      - name: TEST_AUTHN
        methods:
          - local
  authorization:
    execs:
      - name: default
        methods:
          - local
      - name: TEST_AUTHZ
        methods:
          - local
  accounting:
    connections:
      - name: default
        none: true
      - name: TEST_CONN
        none: true
    execs:
      - name: default
        none: true
      - name: TEST_EXEC
        none: true
```

CLI pushed to device:
```
aaa authentication login default local
aaa authentication login TEST_AUTHN local
aaa authorization exec default local
aaa authorization exec TEST_AUTHZ local
aaa accounting exec default none
aaa accounting exec TEST_EXEC none
aaa accounting connection default none
aaa accounting connection TEST_CONN none
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)