### PR TITLE
feat: Add enum-to-boolean translation for port_security_aging_type

### DIFF
--- a/iosxe_templates.tf
+++ b/iosxe_templates.tf
@@ -2,30 +2,38 @@ locals {
   templates = flatten([
     for device in local.devices : [
       for template in try(local.device_config[device.name].templates, []) : {
-        key                                            = format("%s/%s", device.name, template.name)
-        device                                         = device.name
-        name                                           = template.name
-        dot1x_pae                                      = try(template.network_access_control.dot1x_pae, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_pae, null)
-        dot1x_max_reauth_req                           = try(template.network_access_control.dot1x_max_reauth_req, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_max_reauth_req, null)
-        dot1x_max_req                                  = try(template.network_access_control.dot1x_max_req, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_max_req, null)
-        dot1x_timeout_tx_period                        = try(template.network_access_control.dot1x_timeout_tx_period, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_tx_period, null)
-        dot1x_timeout_quiet_period                     = try(template.network_access_control.dot1x_timeout_quiet_period, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_quiet_period, null)
-        dot1x_timeout_supp_timeout                     = try(template.network_access_control.dot1x_timeout_supp_timeout, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_supp_timeout, null)
-        dot1x_timeout_ratelimit_period                 = try(template.network_access_control.dot1x_timeout_ratelimit_period, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_ratelimit_period, null)
-        dot1x_timeout_server_timeout                   = try(template.network_access_control.dot1x_timeout_server_timeout, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_server_timeout, null)
-        service_policy_type_control_subscriber         = try(template.service_policy_type_control_subscriber, local.defaults.iosxe.configuration.templates.service_policy_type_control_subscriber, null)
-        service_policy_input                           = try(template.service_policy_input, local.defaults.iosxe.configuration.templates.service_policy_input, null)
-        service_policy_output                          = try(template.service_policy_output, local.defaults.iosxe.configuration.templates.service_policy_output, null)
-        source_template                                = try(template.source_template, local.defaults.iosxe.configuration.templates.source_template, null)
-        switchport_mode_trunk                          = try(template.switchport.mode, local.defaults.iosxe.configuration.templates.switchport.mode, null) == "trunk" ? true : false
-        switchport_mode_access                         = try(template.switchport.mode, local.defaults.iosxe.configuration.templates.switchport.mode, null) == "access" ? true : false
-        switchport_nonegotiate                         = try(template.switchport.nonegotiate, local.defaults.iosxe.configuration.templates.switchport.nonegotiate, null)
-        switchport_block_unicast                       = try(template.switchport.block_unicast, local.defaults.iosxe.configuration.templates.switchport.block_unicast, null)
-        switchport_port_security                       = try(template.switchport.port_security, local.defaults.iosxe.configuration.templates.switchport.port_security, null)
-        switchport_port_security_aging_static          = try(template.switchport.port_security_aging_static, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_static, null)
-        switchport_port_security_aging_time            = try(template.switchport.port_security_aging_time, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_time, null)
-        switchport_port_security_aging_type            = try(template.switchport.port_security_aging_type, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type, null)
-        switchport_port_security_aging_type_inactivity = try(template.switchport.port_security_aging_type_inactivity, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type_inactivity, null)
+        key                                    = format("%s/%s", device.name, template.name)
+        device                                 = device.name
+        name                                   = template.name
+        dot1x_pae                              = try(template.network_access_control.dot1x_pae, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_pae, null)
+        dot1x_max_reauth_req                   = try(template.network_access_control.dot1x_max_reauth_req, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_max_reauth_req, null)
+        dot1x_max_req                          = try(template.network_access_control.dot1x_max_req, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_max_req, null)
+        dot1x_timeout_tx_period                = try(template.network_access_control.dot1x_timeout_tx_period, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_tx_period, null)
+        dot1x_timeout_quiet_period             = try(template.network_access_control.dot1x_timeout_quiet_period, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_quiet_period, null)
+        dot1x_timeout_supp_timeout             = try(template.network_access_control.dot1x_timeout_supp_timeout, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_supp_timeout, null)
+        dot1x_timeout_ratelimit_period         = try(template.network_access_control.dot1x_timeout_ratelimit_period, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_ratelimit_period, null)
+        dot1x_timeout_server_timeout           = try(template.network_access_control.dot1x_timeout_server_timeout, local.defaults.iosxe.configuration.templates.network_access_control.dot1x_timeout_server_timeout, null)
+        service_policy_type_control_subscriber = try(template.service_policy_type_control_subscriber, local.defaults.iosxe.configuration.templates.service_policy_type_control_subscriber, null)
+        service_policy_input                   = try(template.service_policy_input, local.defaults.iosxe.configuration.templates.service_policy_input, null)
+        service_policy_output                  = try(template.service_policy_output, local.defaults.iosxe.configuration.templates.service_policy_output, null)
+        source_template                        = try(template.source_template, local.defaults.iosxe.configuration.templates.source_template, null)
+        switchport_mode_trunk                  = try(template.switchport.mode, local.defaults.iosxe.configuration.templates.switchport.mode, null) == "trunk" ? true : false
+        switchport_mode_access                 = try(template.switchport.mode, local.defaults.iosxe.configuration.templates.switchport.mode, null) == "access" ? true : false
+        switchport_nonegotiate                 = try(template.switchport.nonegotiate, local.defaults.iosxe.configuration.templates.switchport.nonegotiate, null)
+        switchport_block_unicast               = try(template.switchport.block_unicast, local.defaults.iosxe.configuration.templates.switchport.block_unicast, null)
+        switchport_port_security               = try(template.switchport.port_security, local.defaults.iosxe.configuration.templates.switchport.port_security, null)
+        switchport_port_security_aging_static  = try(template.switchport.port_security_aging_static, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_static, null)
+        switchport_port_security_aging_time    = try(template.switchport.port_security_aging_time, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_time, null)
+        switchport_port_security_aging_type = try(
+          try(template.switchport.port_security_aging_type, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type, null) == "inactivity" ? true :
+          try(template.switchport.port_security_aging_type, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type, null) == "absolute" ? null :
+          try(template.switchport.port_security_aging_type, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type, null),
+          null
+        )
+        switchport_port_security_aging_type_inactivity = try(
+          try(template.switchport.port_security_aging_type, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type, null) == "inactivity" ? true : null,
+          null
+        )
         switchport_port_security_maximum_range = try(length(template.switchport.port_security_maximum_ranges) == 0, true) ? null : [for range in template.switchport.port_security_maximum_ranges : {
           range       = try(range.range, local.defaults.iosxe.configuration.templates.switchport.port_security_maximum_ranges.range, null)
           vlan        = try(range.vlan, local.defaults.iosxe.configuration.templates.switchport.port_security_maximum_ranges.vlans, null)


### PR DESCRIPTION
# Title: [IMPL] port_security_aging_type enum translation missing

## Related Issue(s)

Fixes Issue#1173 [Module translation change] (https://wwwin-github.cisco.com/netascode/nac-iosxe/issues/1173)
Related to netascode/nac-iosxe#1062 [Schema Docs Issue] (https://wwwin-github.cisco.com/netascode/nac-iosxe/issues/1062)
Related to netascode/nac-iosxe#1171 [Schema enum change] (https://wwwin-github.cisco.com/netascode/nac-iosxe/issues/1171)

## Proposed Changes

This PR adds enum-to-boolean translation logic for the `port_security_aging_type` attribute in interface templates, enabling the module to translate the schema's enum values (`"absolute"` or `"inactivity"`) into the provider's expected boolean attributes. This completes the fix for Issue #1062 by bridging the gap between the user-friendly enum interface and the provider's YANG-compliant boolean implementation.

### Changes Made:

**1. Module Translation Logic (`iosxe_templates.tf`)**
- Added enum-to-boolean translation for `port_security_aging_type` attribute
- `"inactivity"` enum → both provider booleans (`switchport_port_security_aging_type` and `switchport_port_security_aging_type_inactivity`) = `true`
- `"absolute"` enum → both provider booleans = `null` (omitted, uses default)
- Template expressions (e.g., `"${var.type}"`) pass through correctly for runtime evaluation
- Uses nested `try()` pattern for graceful error handling

### Files Changed

| File | Status | Lines | Description |
|------|--------|-------|-------------|
| `iosxe_templates.tf` | MODIFIED | +9 | Added enum-to-boolean translation logic |
| **Total** | | **+9** | |

## Robot Test(s)

N/A - Robot tests are in schema repository. Module translation validated through end-to-end testing.

**Testing Results:**

### Pre-commit Hooks

**Tools:** terraform fmt, tflint, terraform-docs

**Results:**
```bash
$ pre-commit run --all-files
Terraform fmt............................................................Passed
Terraform validate with tflint...........................................Passed
terraform-docs...........................................................Passed (4 files)
```

### End-to-End Testing

**Device:** 10.81.239.60 (C9000V Switch - IOS-XE 17.15.03)

**Test Results:**
- ✅ Terraform plan: Enum value `"inactivity"` correctly translated to both provider booleans = `true`
- ✅ Terraform apply: Configuration applied successfully via RESTCONF
- ✅ Idempotency: PASSED - "No changes. Your infrastructure matches the configuration." (verified multiple times)
- ✅ Device CLI verification: Confirmed enum value correctly applied
- ✅ Terraform destroy: Configuration successfully removed from device

**Terraform Plan Output:**
```
+ switchport_port_security_aging_type            = true
+ switchport_port_security_aging_type_inactivity = true
```

**Device CLI Verification:**
```cisco
template TEST-PORT-SECURITY-AGING
 switchport mode access
 switchport port-security maximum 10 vlan access
 switchport port-security aging time 120
 switchport port-security aging type inactivity
 switchport port-security aging static
```

**Validation Details:**
- ✅ Enum value `"inactivity"` correctly translated to provider booleans
- ✅ Configuration applied successfully via RESTCONF
- ✅ Idempotency verified (multiple applies show no changes)
- ✅ Destroy functionality verified (configuration cleanly removed)

## Cisco IOS-XE Version

**Target Versions:**
- IOS-XE 17.12.1: All attributes supported
- IOS-XE 17.15.1: All attributes supported

**Version Compatibility:**
- No version-specific features used
- No `test_tags` required
- All attributes are standard across IOS-XE versions

## External Repo Link

**Schema PR:** netascode/nac-iosxe#1175 (https://wwwin-github.cisco.com/netascode/nac-iosxe/pull/1175) 

The schema PR changes `port_security_aging_type` from boolean to enum. This module PR translates those enum values to provider boolean attributes. Both PRs should be reviewed together.

## Checklist

- [x] Latest commit is rebased from main with merge conflicts resolved
- [x] Translation logic implemented and tested
- [x] Pre-commit hooks passed
- [x] End-to-end testing completed
  - Terraform plan/apply verified
  - Idempotency verified
  - Device CLI verification confirmed
  - Destroy functionality verified
- [x] Assigned reviewers
- [x] Assigned to self

## Additional Notes

### Implementation Pattern

The module uses nested `try()` pattern for graceful handling:

**1. Default Value Resolution**
```terraform
try(template.switchport.port_security_aging_type, local.defaults.iosxe.configuration.templates.switchport.port_security_aging_type, null)
```
- Checks device-specific configuration first
- Falls back to default configuration
- Returns `null` if neither specified

**2. Enum Value Translation**
```terraform
== "inactivity" ? true : == "absolute" ? null : <pass-through>
```
- Translates enum to provider booleans
- Handles template expressions (passes through unchanged)
- Returns `null` for absolute (default behavior)

### Configuration Examples

**Example 1: Inactivity Aging Type**
```yaml
templates:
  - name: ACCESS-PORT
    switchport:
      port_security_aging_type: "inactivity"
```

**Module Output:**
```terraform
switchport_port_security_aging_type            = true
switchport_port_security_aging_type_inactivity = true
```

**Example 2: Absolute Aging Type**
```yaml
templates:
  - name: STATIC-PORT
    switchport:
      port_security_aging_type: "absolute"
```

**Module Output:**
```terraform
switchport_port_security_aging_type            = null
switchport_port_security_aging_type_inactivity = null
```

**Example 3: Template Expression**
```yaml
templates:
  - name: DYNAMIC-PORT
    switchport:
      port_security_aging_type: "{{ aging_type }}"
```

**Module Output:** Passes through unchanged for runtime evaluation

### Backwards Compatibility

⚠️ **Breaking Change** - Requires Schema PR (#1171) to be merged first

- New enum interface replaces boolean interface
- Existing configurations with boolean values will need migration
- Template expressions (Jinja2 variables) continue to work
- Module translation handles enum values transparently
