### PR TITLE
fix(system): remove interface dependencies from system depends_on

### DIFF
--- a/iosxe_system.tf
+++ b/iosxe_system.tf
@@ -269,11 +269,6 @@ resource "iosxe_system" "system" {
 
   depends_on = [
     iosxe_vrf.vrf,
-    iosxe_interface_ethernet.ethernet,
-    iosxe_interface_loopback.loopback,
-    iosxe_interface_vlan.vlan,
-    iosxe_interface_port_channel.port_channel,
-    iosxe_interface_port_channel_subinterface.port_channel_subinterface,
     iosxe_policy_map.policy_map
   ]
 }
@@ -300,11 +295,6 @@ resource "iosxe_sla" "sla" {
 
   depends_on = [
     iosxe_vrf.vrf,
-    iosxe_interface_ethernet.ethernet,
-    iosxe_interface_loopback.loopback,
-    iosxe_interface_vlan.vlan,
-    iosxe_interface_port_channel.port_channel,
-    iosxe_interface_port_channel_subinterface.port_channel_subinterface,
     iosxe_policy_map.policy_map
   ]
 }

--- a/iosxe_system.tf
+++ b/iosxe_system.tf
@@ -269,6 +269,10 @@ resource "iosxe_system" "system" {
 
   depends_on = [
     iosxe_vrf.vrf,
+    iosxe_interface_loopback.loopback,
+    iosxe_interface_vlan.vlan,
+    iosxe_interface_port_channel.port_channel,
+    iosxe_interface_port_channel_subinterface.port_channel_subinterface,
     iosxe_policy_map.policy_map
   ]
 }
@@ -295,6 +299,10 @@ resource "iosxe_sla" "sla" {
 
   depends_on = [
     iosxe_vrf.vrf,
+    iosxe_interface_loopback.loopback,
+    iosxe_interface_vlan.vlan,
+    iosxe_interface_port_channel.port_channel,
+    iosxe_interface_port_channel_subinterface.port_channel_subinterface,
     iosxe_policy_map.policy_map
   ]
 }


### PR DESCRIPTION
## Summary

Remove only `iosxe_interface_ethernet` from the `iosxe_system` and `iosxe_sla` resource `depends_on` lists. Logical interface dependencies (loopback, vlan, port-channel, port-channel-subinterface) are retained because they are required for correct destroy ordering.

## Problem

When configuring IS-IS routing on ethernet interfaces, the data model needs to:

1. Enable `ip routing` on the device (via `iosxe_system`)
2. Create the IS-IS process (via `iosxe_isis`) — requires `ip routing` to be enabled
3. Bind the ethernet interface to the IS-IS process (via `ip_router_isis` attribute on `iosxe_interface_ethernet`) — requires the IS-IS process to exist
4. Configure IS-IS interface parameters (via `iosxe_interface_isis`) — requires the interface to exist

The current `depends_on` in `iosxe_system` forces the system resource to wait for **all** interface resources to complete first. This creates a circular dependency:

```
iosxe_system → waits for → iosxe_interface_ethernet
iosxe_interface_ethernet → waits for → iosxe_isis (IS-IS process must exist for ip_router_isis binding)
iosxe_isis → waits for → iosxe_system (ip routing must be enabled for IS-IS)
```

## Fix

Remove only `iosxe_interface_ethernet` from `depends_on` — this is the interface type causing the IS-IS circular dependency, and it is safe to remove because physical ethernet interfaces always exist on the device hardware (they cannot be created or destroyed by Terraform).

Logical interface dependencies (loopback, vlan, port-channel, port-channel-subinterface) are **retained** because the `iosxe_system` resource has source-interface attributes (`ip_domain_lookup_source_interface`, `ip_tacacs_source_interface`, `ip_radius_source_interface`, `ip_ssh_source_interface`, `tftp_source_interface`) that can reference these logical interfaces.

### Why logical interface dependencies must stay

**Apply direction**: IOS-XE does accept configuring a source-interface reference (e.g., `ip tacacs source-interface Loopback200`) before the Loopback itself exists — so the dependency is not strictly needed for apply.

**Destroy direction**: IOS-XE **rejects** removing a source-interface reference (e.g., `no ip tacacs source-interface Loopback200`) if the Loopback has already been deleted. Without the dependency, `terraform destroy` runs system and loopback deletion in parallel, and the loopback can be deleted before system has a chance to unconfigure the source-interface reference — causing the destroy to fail.

The dependency ensures correct destroy ordering: system is destroyed first (unconfigures source-interface references while logical interfaces still exist), then logical interfaces are destroyed.

## Testing

### Source-interface ordering validation (Daniel's feedback)

Created a dedicated test fixture with `iosxe_system` configured with four source-interface attributes all pointing to `Loopback200`, which is created in the same apply:

- `ip_domain_lookup_source_interface` → Loopback 200
- `ip_tacacs_source_interface` → Loopback 200
- `ip_ssh_source_interface` → Loopback 200
- `tftp_source_interface` → Loopback 200

**With logical interface dependencies retained (this PR):**
- Apply: Loopback200 created first, then system configured source-interfaces → **PASSED**
- Idempotency: No changes on second apply → **PASSED**
- Destroy: System destroyed first (source-interface references removed while Loopback200 still exists), then Loopback200 deleted → **PASSED**

**With all interface dependencies removed (original approach):**
- Apply: System and Loopback200 created in parallel — IOS-XE accepted source-interface before loopback existed → **PASSED**
- Destroy: System and Loopback200 destroyed in parallel — Loopback200 deleted before system could unconfigure `no ip tacacs source-interface Loopback200` → **FAILED** (device rejected the command)

This confirms the logical interface dependencies are needed for destroy ordering.

### Broader regression testing

- [x] Tested locally with 22+ atomic fixtures (no regressions)
- [x] Verified IS-IS multi-protocol (IS-IS + OSPF) scenario passes end-to-end
- [x] Validated source-interface destroy ordering with dedicated fixture (apply + idempotency + destroy)
- [x] Confirmed IOS-XE behavior: accepts forward source-interface reference, rejects reverse removal after interface deletion
- [x] Pre-commit hooks pass (terraform fmt, tflint, terraform-docs)

*P.S. — This comment was drafted using voice-to-text via Claude Code. If the tone comes across as overly direct or terse, please know that's just how it tends to phrase things. No offense or criticism is intended — this is purely an objective technical review of the PR. Thanks for understanding! 🙂*