### PR TITLE
fix(interfaces): add system dependency to PIM interface resources

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -783,6 +783,7 @@ resource "iosxe_interface_pim" "ethernet_pim" {
   dr_priority       = each.value.pim_dr_priority
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_ethernet.ethernet
   ]
 }
@@ -803,6 +804,7 @@ resource "iosxe_interface_pim" "ethernet_pim_unmanaged" {
   dr_priority       = each.value.pim_dr_priority
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_ethernet.ethernet_unmanaged
   ]
 
@@ -1064,6 +1066,7 @@ resource "iosxe_interface_pim" "loopback_pim" {
   dr_priority       = each.value.pim_dr_priority
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_loopback.loopback
   ]
 }
@@ -1360,6 +1363,7 @@ resource "iosxe_interface_pim" "vlan_pim" {
   dr_priority       = each.value.pim_dr_priority
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_vlan.vlan
   ]
 }
@@ -1781,6 +1785,7 @@ resource "iosxe_interface_pim" "port_channel_pim" {
   dr_priority       = each.value.pim_dr_priority
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_port_channel.port_channel
   ]
 }
@@ -2077,6 +2082,7 @@ resource "iosxe_interface_pim" "port_channel_subinterface_pim" {
   dr_priority       = each.value.pim_dr_priority
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_port_channel_subinterface.port_channel_subinterface
   ]
 }

--- a/iosxe_pim.tf
+++ b/iosxe_pim.tf
@@ -64,6 +64,7 @@ resource "iosxe_pim" "pim" {
   }]
 
   depends_on = [
+    iosxe_system.system,
     iosxe_interface_pim.loopback_pim,
     iosxe_access_list_standard.access_list_standard,
     iosxe_access_list_extended.access_list_extended

--- a/iosxe_pim_ipv6.tf
+++ b/iosxe_pim_ipv6.tf
@@ -14,6 +14,7 @@ resource "iosxe_pim_ipv6" "pim_ipv6" {
   }]
 
   depends_on = [
+    iosxe_system.system,
     iosxe_vrf.vrf
   ]
 }


### PR DESCRIPTION
## Summary

- Add `iosxe_system.system` to the `depends_on` list for all `iosxe_interface_pim` resources (ethernet, ethernet_unmanaged, loopback, vlan, port_channel, port_channel_subinterface)
- Add `iosxe_system.system` to the `depends_on` list for `iosxe_pim.pim` and `iosxe_pim_ipv6.pim_ipv6`

## Problem

IOS-XE requires `ip multicast-routing` (or `ipv6 multicast-routing`) to be enabled before PIM can be configured on any interface or globally. The current module does not express this dependency for any PIM resource.

During `terraform destroy`, this causes a failure: Terraform may attempt to remove `ip multicast-routing` (via the system resource) before removing PIM configurations. The device rejects this with:

```
Error: Client Error
failed to edit config: operation failed
Device refused: no ip multicast-routing
```

This was discovered while testing 32 atomic PIM fixtures — all PIM configurations deploy successfully and pass functional tests, but fail during destroy due to incorrect resource ordering.

## Fix

Add `iosxe_system.system` to the `depends_on` of every PIM resource:

- `iosxe_interface_pim` (6 resources: ethernet, ethernet_unmanaged, loopback, vlan, port_channel, port_channel_subinterface)
- `iosxe_pim` (global IPv4 PIM)
- `iosxe_pim_ipv6` (global IPv6 PIM)

This ensures:
- **Create**: multicast routing is enabled before any PIM config is applied
- **Destroy**: all PIM config is removed before multicast routing is disabled (Terraform destroys in reverse dependency order)

## Related

Related to #251 — that PR addresses the inverse direction (removing interface dependencies from the system resource to fix IS-IS circular dependency). This PR adds the forward direction dependency specifically for PIM resources. The two changes are complementary.

## Test plan

- [x] Tested with 32 atomic PIM fixtures covering all PIM interface types and global PIM
- [x] Verified `terraform destroy` succeeds with both this PR and #251 applied together against local module
- [x] All pre-commit hooks pass (terraform_fmt, tflint, terraform-docs)

*P.S. — This comment was drafted using voice-to-text via Claude Code. If the tone comes across as overly direct or terse, please know that's just how it tends to phrase things. No offense or criticism is intended — this is purely an objective technical review of the PR. Thanks for understanding! 🙂*