### PR TITLE
chore: add release.yaml and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,69 @@
+<!--- Please ensure that the WIP label is not being applied if ready for review -->
+<!--- If the WIP label is applied to your PR, no one will look at it -->
+<!--- Please feel free to ask for help -->
+
+## ✔️ Type of Change
+
+- [ ] 🚀 New feature (new Terraform resource/module file, new HCL logic)
+- [ ] 🐛 Bug fix (corrects an issue in module HCL, dependencies, or locals)
+- [ ] ⚠️ Breaking change (modifies existing module interface or variable structure)
+- [ ] 📄 Documentation update (README, examples)
+- [ ] 🛠️ Refactoring / tech debt (internal improvements, no user-facing changes)
+- [ ] ⚙️ Other (please describe):
+
+## 🔗 Related Issue(s)
+
+<!--- Link the relevant issue(s). Use "Fixes #123" to auto-close on merge. -->
+
+## 📝 Proposed Changes
+
+<!--- Describe what this PR does and why. -->
+
+---
+
+## 🧪 Testing Evidence
+
+> **⚠️ PRs without testing evidence will not be reviewed** (unless this is a docs-only or chore-only change — check N/A below).
+
+- [ ] N/A — this PR does not touch `.tf` files (e.g., docs-only, CI, chore)
+
+### Terraform Validation
+
+<!--- Confirm that the module compiles and plans correctly -->
+
+```bash
+# Paste `terraform init` + `terraform plan` or `terraform apply` output
+```
+
+- [ ] `terraform validate` passes
+- [ ] `terraform plan` produces expected changes (or `terraform apply` on a test device)
+
+---
+
+## 🔗 Cross-Repo Links
+
+<!--- Module PRs often depend on a provider release. Link related PRs/issues. -->
+
+- Provider PR/release this depends on: <!-- e.g., CiscoDevNet/terraform-provider-iosxe#456 or v0.16.0 -->
+- Schema PR: <!-- e.g., netascode/nac-iosxe#789 -->
+
+## ✅ Checklist
+
+### Pre-Submission
+
+- [ ] I have merged/rebased from `main` and resolved all merge conflicts
+- [ ] `terraform validate` passes
+- [ ] Module changes have been tested with `terraform plan` or `terraform apply`
+
+### Code Quality
+
+- [ ] New `.tf` file(s) follow existing module patterns (`for_each`, `try()` hierarchy, `depends_on`)
+- [ ] Variable references use the `local.device_config` → `local.defaults` fallback pattern
+- [ ] No hardcoded values — all config comes from the YAML data model
+
+### Labels & Assignment
+
+- [ ] I have assigned at least one label that aligns with `release.yaml` categories: `feature`, `enhancement`, `bug`, `fix`, `breaking-change`, `documentation`, `refactor`, `tech-debt`, `chore`, or `dependencies`
+- [ ] Label(s) match the linked GitHub issue label(s) where applicable
+- [ ] PR is assigned to myself
+- [ ] One or more reviewers are assigned

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,39 @@
+# Configures GitHub's automatically generated release notes.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - "ignore-for-release"
+    authors:
+      - "dependabot[bot]"
+
+  categories:
+    - title: "⚠️ Breaking Changes"
+      labels:
+        - "breaking-change"
+
+    - title: "🚀 New Features"
+      labels:
+        - "feature"
+        - "enhancement"
+
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "bug"
+        - "fix"
+
+    - title: "📄 Documentation"
+      labels:
+        - "documentation"
+
+    - title: "🛠️ Internal & Maintenance"
+      labels:
+        - "refactor"
+        - "tech-debt"
+        - "chore"
+        - "dependencies"
+
+    - title: "⚙️ Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
## ✔️ Type of Change

- [x] ⚙️ Other: Add release automation config and PR template

## 🔗 Related Issue(s)

N/A — foundational repo configuration.

## 📝 Proposed Changes

### 1. `.github/release.yaml` (new)

Adds GitHub auto-generated release notes configuration with 6 standardized changelog categories:

| Category | Labels |
|----------|--------|
| ⚠️ Breaking Changes | `breaking-change` |
| 🚀 New Features | `feature`, `enhancement` |
| 🐛 Bug Fixes | `bug`, `fix` |
| 📄 Documentation | `documentation` |
| 🛠️ Internal & Maintenance | `refactor`, `tech-debt`, `chore`, `dependencies` |
| ⚙️ Other Changes | `*` (catch-all) |

PRs labeled `ignore-for-release` are excluded. Dependabot PRs are excluded by author.

### 2. `.github/pull_request_template.md` (new)

Adds a PR template tailored to the module's Terraform HCL workflow:
- **Type of Change** checkboxes (aligned with release.yaml categories)
- **Testing section** focused on `terraform validate` / `terraform plan`
- **N/A escape hatch** for docs-only / chore-only PRs
- **Cross-repo links** section for provider dependencies + schema PRs
- **Code quality checks** specific to module patterns (`for_each`, `try()` hierarchy)
- **Mandatory label assignment** — requires at least one release.yaml-aligned label

### 3. Labels created on this repo

New labels: `breaking-change`, `feature`, `fix`, `refactor`, `tech-debt`, `chore`, `testing`, `ignore-for-release`.

---

## 🧪 Testing Evidence

- [x] N/A — this PR does not touch `.tf` files (repo config only)

## ✅ Checklist

### Labels & Assignment

- [x] I have assigned at least one label that aligns with `release.yaml` categories: `chore`
- [x] PR is assigned to myself

---

Companion PRs:
- Schema: https://wwwin-github.cisco.com/netascode/nac-iosxe/pull/1240
- Provider: CiscoDevNet/terraform-provider-iosxe (pending)