### PR TITLE
fix(acl): gate icmp_msg_code on numeric icmp_message_type to fix idempotency drift

### DIFF
--- a/iosxe_access_lists.tf
+++ b/iosxe_access_lists.tf
@@ -87,7 +87,7 @@ locals {
           tos                           = try(e.tos, local.defaults.iosxe.configuration.access_lists.extended.entries.tos, null)
           icmp_named_msg_type           = can(tonumber(try(e.icmp_message_type, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_type, ""))) ? null : try(e.icmp_message_type, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_type, null)
           icmp_msg_type                 = can(tonumber(try(e.icmp_message_type, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_type, ""))) ? try(e.icmp_message_type, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_type, null) : null
-          icmp_msg_code                 = try(e.icmp_message_code, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_code, null)
+          icmp_msg_code                 = can(tonumber(try(e.icmp_message_type, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_type, ""))) ? try(e.icmp_message_code, local.defaults.iosxe.configuration.access_lists.extended.entries.icmp_message_code, null) : null
           log                           = try(e.log, local.defaults.iosxe.configuration.access_lists.extended.entries.log, null)
           log_input                     = try(e.log_input, local.defaults.iosxe.configuration.access_lists.extended.entries.log_input, null)
         }]


### PR DESCRIPTION
## Summary

- Fixes idempotency issue where extended ACLs with named ICMP message types (e.g., `echo`, `unreachable`) show changes on every `terraform plan`
- Gates `icmp_msg_code` behind the same `can(tonumber(...))` check already used for `icmp_msg_type` and `icmp_named_msg_type`

## Root Cause

The YANG model for extended ACL ICMP fields uses a choice node (`icmp-msg-choice`) with two mutually exclusive cases:

| Case | Provider attributes | When to use |
|------|-------------------|-------------|
| Named | `icmp_named_msg_type` (string) | `echo`, `unreachable`, etc. |
| Numeric | `icmp_msg_type` (int) + `icmp_msg_code` (int) | Type 3, code 4, etc. |

Previously, `icmp_msg_code` was passed unconditionally. When a user specified a named type with a code (e.g., `icmp_message_type: unreachable` + `icmp_message_code: 4`), the module sent both `icmp_named_msg_type` and `icmp_msg_code` to the provider — violating the YANG choice constraint. The device normalized this to the numeric case, and the provider could not read back the named type, causing perpetual drift.

## Testing

Consider the below data model:

```yaml
---
iosxe:
  devices:
    - name: xeac-cat8kv-3
      host: 192.0.2.10
      protocol: restconf
      configuration:
        access_lists:
          extended:
            - name: EXTENDED_ACL_ICMP
              entries:
                - sequence: 10
                  remark: "Allow ping"
                - sequence: 20
                  action: permit
                  protocol: icmp
                  source:
                    prefix: 10.0.0.0
                    prefix_mask: 0.255.255.255
                  destination:
                    any: true
                  icmp_message_type: echo
                - sequence: 30
                  action: permit
                  protocol: icmp
                  source:
                    any: true
                  destination:
                    prefix: 10.0.0.0
                    prefix_mask: 0.255.255.255
                  icmp_message_type: echo-reply
                - sequence: 40
                  action: permit
                  protocol: icmp
                  source:
                    any: true
                  destination:
                    any: true
                  icmp_message_type: unreachable
                  icmp_message_code: 4
                - sequence: 50
                  action: deny
                  protocol: icmp
                  source:
                    any: true
                  destination:
                    any: true
                  log: true

```

### Reproduced Issue

Initial apply:

```
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=f5712551f5c2f7dc450328f91ee3beb90f5ab68d]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_DATA"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_DATA]
module.iosxe.iosxe_policy_map.policy_map["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/20"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=20]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/30"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=30]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_MULTI"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_MULTI]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/10"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=10]
module.iosxe.iosxe_vlan_access_map.vlan_access_map["xeac-cat9kv-uadp-3/VACL_MAP"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:access-map=VACL_MAP,10]
module.iosxe.iosxe_aaa.aaa["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/violation"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=violation]
module.iosxe.iosxe_template.template["xeac-c9300-1/IBNS_INTF_TMPL_1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/template/Cisco-IOS-XE-template:template_details=IBNS_INTF_TMPL_1]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/template-deactivated"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=template-deactivated]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"] will be created
  + resource "iosxe_access_list_extended" "access_list_extended" {
      + device  = "xeac-cat8kv-3"
      + entries = [
          + {
              + remark   = "Allow ping"
              + sequence = 10
            },
          + {
              + ace_rule_action     = "permit"
              + ace_rule_protocol   = "icmp"
              + destination_any     = true
              + icmp_named_msg_type = "echo"
              + sequence            = 20
              + source_prefix       = "10.0.0.0"
              + source_prefix_mask  = "0.255.255.255"
            },
          + {
              + ace_rule_action         = "permit"
              + ace_rule_protocol       = "icmp"
              + destination_prefix      = "10.0.0.0"
              + destination_prefix_mask = "0.255.255.255"
              + icmp_named_msg_type     = "echo-reply"
              + sequence                = 30
              + source_any              = true
            },
          + {
              + ace_rule_action     = "permit"
              + ace_rule_protocol   = "icmp"
              + destination_any     = true
              + icmp_msg_code       = 4
              + icmp_named_msg_type = "unreachable"
              + sequence            = 40
              + source_any          = true
            },
          + {
              + ace_rule_action   = "deny"
              + ace_rule_protocol = "icmp"
              + destination_any   = true
              + log               = true
              + sequence          = 50
              + source_any        = true
            },
        ]
      + id      = (known after apply)
      + name    = "EXTENDED_ACL_ICMP"
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "CrCs1n8KFgqabYE98QST9vyl3FXF4bLnd4rLrQ7Fj4M=" -> (known after apply)
      ~ content_base64sha512 = "OOQwv9aU46kDAgDOUhO0vJMIw7HxXPcbCrfxs8qZPBrRjLP/zsXzmzFtMC7xD6QaFydtWwq7UUs/RUDVrYn99g==" -> (known after apply)
      ~ content_md5          = "f6b23fe98a5a71c3f19febd035c59489" -> (known after apply)
      ~ content_sha1         = "f5712551f5c2f7dc450328f91ee3beb90f5ab68d" -> (known after apply)
      ~ content_sha256       = "0ab0acd67f0a160a9a6d813df10493f6fca5dc55c5e1b2e7778acbad0ec58f83" -> (known after apply)
      ~ content_sha512       = "38e430bfd694e3a9030200ce5213b4bc9308c3b1f15cf71b0ab7f1b3ca993c1ad18cb3ffcec5f39b316d302ef10fa41a17276d5b0abb514b3f4540d5ad89fdf6" -> (known after apply)
      ~ id                   = "f5712551f5c2f7dc450328f91ee3beb90f5ab68d" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=f5712551f5c2f7dc450328f91ee3beb90f5ab68d]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=aeb123a11cf7c033f76b29ca2aa2acf0ec895fe0]
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Creating...
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP]

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
```

Idempotency check fails:

```
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=aeb123a11cf7c033f76b29ca2aa2acf0ec895fe0]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/20"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=20]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/30"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=30]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_DATA"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_DATA]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/10"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=10]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_MULTI"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_MULTI]
module.iosxe.iosxe_policy_map.policy_map["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS]
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Refreshing state... [id=Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP]
module.iosxe.iosxe_vlan_access_map.vlan_access_map["xeac-cat9kv-uadp-3/VACL_MAP"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:access-map=VACL_MAP,10]
module.iosxe.iosxe_template.template["xeac-c9300-1/IBNS_INTF_TMPL_1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/template/Cisco-IOS-XE-template:template_details=IBNS_INTF_TMPL_1]
module.iosxe.iosxe_aaa.aaa["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/violation"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=violation]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/template-deactivated"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=template-deactivated]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"] will be updated in-place
  ~ resource "iosxe_access_list_extended" "access_list_extended" {
      ~ entries = [
          ~ {
              + icmp_named_msg_type = "unreachable"
                # (6 unchanged attributes hidden)
            },
            # (4 unchanged elements hidden)
        ]
        id      = "Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP"
        name    = "EXTENDED_ACL_ICMP"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Modifying... [id=Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP]
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Modifications complete after 0s [id=Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Issue Fixed on This Branch

Initial apply:

```
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=f5712551f5c2f7dc450328f91ee3beb90f5ab68d]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_DATA"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_DATA]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_MULTI"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_MULTI]
module.iosxe.iosxe_policy_map.policy_map["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/10"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=10]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/30"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=30]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/20"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=20]
module.iosxe.iosxe_vlan_access_map.vlan_access_map["xeac-cat9kv-uadp-3/VACL_MAP"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:access-map=VACL_MAP,10]
module.iosxe.iosxe_template.template["xeac-c9300-1/IBNS_INTF_TMPL_1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/template/Cisco-IOS-XE-template:template_details=IBNS_INTF_TMPL_1]
module.iosxe.iosxe_aaa.aaa["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/violation"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=violation]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/template-deactivated"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=template-deactivated]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"] will be created
  + resource "iosxe_access_list_extended" "access_list_extended" {
      + device  = "xeac-cat8kv-3"
      + entries = [
          + {
              + remark   = "Allow ping"
              + sequence = 10
            },
          + {
              + ace_rule_action     = "permit"
              + ace_rule_protocol   = "icmp"
              + destination_any     = true
              + icmp_named_msg_type = "echo"
              + sequence            = 20
              + source_prefix       = "10.0.0.0"
              + source_prefix_mask  = "0.255.255.255"
            },
          + {
              + ace_rule_action         = "permit"
              + ace_rule_protocol       = "icmp"
              + destination_prefix      = "10.0.0.0"
              + destination_prefix_mask = "0.255.255.255"
              + icmp_named_msg_type     = "echo-reply"
              + sequence                = 30
              + source_any              = true
            },
          + {
              + ace_rule_action     = "permit"
              + ace_rule_protocol   = "icmp"
              + destination_any     = true
              + icmp_named_msg_type = "unreachable"
              + sequence            = 40
              + source_any          = true
            },
          + {
              + ace_rule_action   = "deny"
              + ace_rule_protocol = "icmp"
              + destination_any   = true
              + log               = true
              + sequence          = 50
              + source_any        = true
            },
        ]
      + id      = (known after apply)
      + name    = "EXTENDED_ACL_ICMP"
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] must be replaced
-/+ resource "local_sensitive_file" "model" {
      ~ content              = (sensitive value) # forces replacement
      ~ content_base64sha256 = "CrCs1n8KFgqabYE98QST9vyl3FXF4bLnd4rLrQ7Fj4M=" -> (known after apply)
      ~ content_base64sha512 = "OOQwv9aU46kDAgDOUhO0vJMIw7HxXPcbCrfxs8qZPBrRjLP/zsXzmzFtMC7xD6QaFydtWwq7UUs/RUDVrYn99g==" -> (known after apply)
      ~ content_md5          = "f6b23fe98a5a71c3f19febd035c59489" -> (known after apply)
      ~ content_sha1         = "f5712551f5c2f7dc450328f91ee3beb90f5ab68d" -> (known after apply)
      ~ content_sha256       = "0ab0acd67f0a160a9a6d813df10493f6fca5dc55c5e1b2e7778acbad0ec58f83" -> (known after apply)
      ~ content_sha512       = "38e430bfd694e3a9030200ce5213b4bc9308c3b1f15cf71b0ab7f1b3ca993c1ad18cb3ffcec5f39b316d302ef10fa41a17276d5b0abb514b3f4540d5ad89fdf6" -> (known after apply)
      ~ id                   = "f5712551f5c2f7dc450328f91ee3beb90f5ab68d" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=f5712551f5c2f7dc450328f91ee3beb90f5ab68d]
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=aeb123a11cf7c033f76b29ca2aa2acf0ec895fe0]
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Creating...
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Creation complete after 0s [id=Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP]

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
```

Idempotency check passes:

```
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=aeb123a11cf7c033f76b29ca2aa2acf0ec895fe0]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_MULTI"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_MULTI]
module.iosxe.iosxe_policy_map.policy_map["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/30"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=30]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/10"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=10]
module.iosxe.iosxe_vlan.vlan["xeac-cat9kv-uadp-3/20"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:vlan-list=20]
module.iosxe.iosxe_vlan_group.vlan_group["xeac-cat9kv-uadp-3/GROUP_DATA"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:group=GROUP_DATA]
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv-3/EXTENDED_ACL_ICMP"]: Refreshing state... [id=Cisco-IOS-XE-native:native/ip/access-list/Cisco-IOS-XE-acl:extended=EXTENDED_ACL_ICMP]
module.iosxe.iosxe_vlan_access_map.vlan_access_map["xeac-cat9kv-uadp-3/VACL_MAP"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vlan/Cisco-IOS-XE-vlan:access-map=VACL_MAP,10]
module.iosxe.iosxe_template.template["xeac-c9300-1/IBNS_INTF_TMPL_1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/template/Cisco-IOS-XE-template:template_details=IBNS_INTF_TMPL_1]
module.iosxe.iosxe_aaa.aaa["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/violation"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=violation]
module.iosxe.iosxe_policy_map_event.policy_map_event["xeac-c9300-1/PM_IBNS_FIXTURE_ACTIONS/template-deactivated"]: Refreshing state... [id=Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map=PM_IBNS_FIXTURE_ACTIONS/event=template-deactivated]
module.iosxe.iosxe_system.system["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat9kv-uadp-3"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~90%
- **AI Reason**: bug fix for YANG choice constraint violation