### PR TITLE
fix(aaa): add missing iosxe_vrf.vrf dependency

### DIFF
--- a/iosxe_aaa.tf
+++ b/iosxe_aaa.tf
@@ -51,6 +51,7 @@ resource "iosxe_aaa" "aaa" {
     iosxe_interface_port_channel.port_channel,
     iosxe_interface_port_channel_subinterface.port_channel_subinterface,
     iosxe_interface_vlan.vlan,
+    iosxe_vrf.vrf,
   ]
 }
 


### PR DESCRIPTION
## Summary
- Adds `iosxe_vrf.vrf` to the `depends_on` block of `iosxe_aaa` resource, ensuring proper create/destroy ordering when TACACS groups reference a VRF

Fixes https://github.com/netascode/terraform-iosxe-nac-iosxe/issues/243

## Problem
The `iosxe_aaa` resource references VRF names via `tacacs_groups.vrf` but had no dependency on `iosxe_vrf.vrf`. During `terraform destroy`, the VRF could be deleted before AAA, causing "VRF must be created first, deleted last" errors. This is the same pattern fixed for `iosxe_snmp_server` in #241.

## Testing

Consider the below data model:

```
---
iosxe:
  devices:
    - name: xeac-cat8kv-2
      host: 192.0.2.10
      protocol: netconf
      configuration:
        vrfs:
          - name: TACACS-VRF
            description: VRF for TACACS testing
            route_distinguisher: "65000:100"
        aaa:
          new_model: true
          tacacs_groups:
            - name: TACACS-GROUP
              vrf: TACACS-VRF
          authentication:
            logins:
              - name: default
                methods:
                  - local
          authorization:
            execs:
              - name: default
                methods:
                  - local
          accounting:
            connections:
              - name: default
                none: true
            execs:
              - name: default
                none: true
        system:
          hostname: xeac-cat8kv-2
          ip_routing: true
          ipv6_unicast_routing: true
          http:
            server: true
            secure_server: true
            authentication_local: true
```

With this data model and with the fix integrated into this branch, both application and destroy via Terraform successfully works. Terraform application:

```
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"] will be created
  + resource "iosxe_aaa" "aaa" {
      + device                  = "xeac-cat8kv-2"
      + group_server_tacacsplus = [
          + {
              + name = "TACACS-GROUP"
              + vrf  = "TACACS-VRF"
            },
        ]
      + id                      = (known after apply)
      + new_model               = true
    }

  # module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"] will be created
  + resource "iosxe_aaa_accounting" "aaa_accounting" {
      + connections = [
          + {
              + name = "default"
              + none = true
            },
        ]
      + device      = "xeac-cat8kv-2"
      + execs       = [
          + {
              + name = "default"
              + none = true
            },
        ]
      + id          = (known after apply)
    }

  # module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"] will be created
  + resource "iosxe_aaa_authentication" "aaa_authentication" {
      + device                 = "xeac-cat8kv-2"
      + dot1x_default_a1_local = false
      + dot1x_default_a2_local = false
      + dot1x_default_a3_local = false
      + dot1x_default_a4_local = false
      + id                     = (known after apply)
      + logins                 = [
          + {
              + a1_enable = false
              + a1_line   = false
              + a1_local  = true
              + a1_none   = false
              + a2_enable = false
              + a2_line   = false
              + a2_local  = false
              + a2_none   = false
              + a3_enable = false
              + a3_line   = false
              + a3_local  = false
              + a3_none   = false
              + a4_enable = false
              + a4_line   = false
              + a4_local  = false
              + a4_none   = false
              + name      = "default"
            },
        ]
    }

  # module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"] will be created
  + resource "iosxe_aaa_authorization" "aaa_authorization" {
      + device = "xeac-cat8kv-2"
      + execs  = [
          + {
              + a1_if_authenticated = false
              + a1_local            = true
              + a1_radius           = false
              + a1_tacacs           = false
              + a2_if_authenticated = false
              + a2_local            = false
              + a2_radius           = false
              + a2_tacacs           = false
              + a3_if_authenticated = false
              + a3_local            = false
              + a3_radius           = false
              + a3_tacacs           = false
              + a4_if_authenticated = false
              + a4_local            = false
              + a4_radius           = false
              + a4_tacacs           = false
              + name                = "default"
            },
        ]
      + id     = (known after apply)
    }

  # module.iosxe.iosxe_system.system["xeac-cat8kv-2"] will be created
  + resource "iosxe_system" "system" {
      + device                       = "xeac-cat8kv-2"
      + enable_secret_wo             = (write-only attribute)
      + hostname                     = "xeac-cat8kv-2"
      + id                           = (known after apply)
      + ip_http_authentication_local = true
      + ip_http_secure_server        = true
      + ip_http_server               = true
      + ip_routing                   = true
      + ipv6_unicast_routing         = true
    }

  # module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"] will be created
  + resource "iosxe_vrf" "vrf" {
      + description = "VRF for TACACS testing"
      + device      = "xeac-cat8kv-2"
      + id          = (known after apply)
      + name        = "TACACS-VRF"
      + rd          = "65000:100"
    }

  # module.iosxe.module.model.local_sensitive_file.defaults[0] will be created
  + resource "local_sensitive_file" "defaults" {
      + content              = (sensitive value)
      + content_base64sha256 = (known after apply)
      + content_base64sha512 = (known after apply)
      + content_md5          = (known after apply)
      + content_sha1         = (known after apply)
      + content_sha256       = (known after apply)
      + content_sha512       = (known after apply)
      + directory_permission = "0700"
      + file_permission      = "0700"
      + filename             = "defaults.yaml"
      + id                   = (known after apply)
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] will be created
  + resource "local_sensitive_file" "model" {
      + content              = (sensitive value)
      + content_base64sha256 = (known after apply)
      + content_base64sha512 = (known after apply)
      + content_md5          = (known after apply)
      + content_sha1         = (known after apply)
      + content_sha256       = (known after apply)
      + content_sha512       = (known after apply)
      + directory_permission = "0700"
      + file_permission      = "0700"
      + filename             = "model.yaml"
      + id                   = (known after apply)
    }

Plan: 8 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.defaults[0]: Creating...
module.iosxe.module.model.local_sensitive_file.defaults[0]: Creation complete after 0s [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.model[0]: Creating...
module.iosxe.module.model.local_sensitive_file.model[0]: Creation complete after 0s [id=28405f652793bc9121ef0c30cce058cc833d254a]
module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"]: Creating...
module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"]: Creation complete after 2s [id=Cisco-IOS-XE-native:native/vrf/definition=TACACS-VRF]
module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"]: Creating...
module.iosxe.iosxe_system.system["xeac-cat8kv-2"]: Creating...
module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"]: Creation complete after 0s [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"]: Creating...
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"]: Creating...
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"]: Creating...
module.iosxe.iosxe_system.system["xeac-cat8kv-2"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"]: Creation complete after 2s [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]

Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
```

Terraform destruction:

```
$ terraform destroy
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ciscodevnet/iosxe in /Users/chart2/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
module.iosxe.module.model.local_sensitive_file.defaults[0]: Refreshing state... [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.model[0]: Refreshing state... [id=28405f652793bc9121ef0c30cce058cc833d254a]
module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"]: Refreshing state... [id=Cisco-IOS-XE-native:native/vrf/definition=TACACS-VRF]
module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_system.system["xeac-cat8kv-2"]: Refreshing state... [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"]: Refreshing state... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"] will be destroyed
  - resource "iosxe_aaa" "aaa" {
      - device                  = "xeac-cat8kv-2" -> null
      - group_server_tacacsplus = [
          - {
              - name = "TACACS-GROUP" -> null
              - vrf  = "TACACS-VRF" -> null
            },
        ] -> null
      - id                      = "Cisco-IOS-XE-native:native/aaa" -> null
      - new_model               = true -> null
    }

  # module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"] will be destroyed
  - resource "iosxe_aaa_accounting" "aaa_accounting" {
      - connections = [
          - {
              - name = "default" -> null
              - none = true -> null
            },
        ] -> null
      - device      = "xeac-cat8kv-2" -> null
      - execs       = [
          - {
              - name = "default" -> null
              - none = true -> null
            },
        ] -> null
      - id          = "Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting" -> null
    }

  # module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"] will be destroyed
  - resource "iosxe_aaa_authentication" "aaa_authentication" {
      - device                 = "xeac-cat8kv-2" -> null
      - dot1x_default_a1_local = false -> null
      - dot1x_default_a2_local = false -> null
      - dot1x_default_a3_local = false -> null
      - dot1x_default_a4_local = false -> null
      - id                     = "Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication" -> null
      - logins                 = [
          - {
              - a1_enable = false -> null
              - a1_line   = false -> null
              - a1_local  = true -> null
              - a1_none   = false -> null
              - a2_enable = false -> null
              - a2_line   = false -> null
              - a2_local  = false -> null
              - a2_none   = false -> null
              - a3_enable = false -> null
              - a3_line   = false -> null
              - a3_local  = false -> null
              - a3_none   = false -> null
              - a4_enable = false -> null
              - a4_line   = false -> null
              - a4_local  = false -> null
              - a4_none   = false -> null
              - name      = "default" -> null
            },
        ] -> null
    }

  # module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"] will be destroyed
  - resource "iosxe_aaa_authorization" "aaa_authorization" {
      - device = "xeac-cat8kv-2" -> null
      - execs  = [
          - {
              - a1_if_authenticated = false -> null
              - a1_local            = true -> null
              - a1_radius           = false -> null
              - a1_tacacs           = false -> null
              - a2_if_authenticated = false -> null
              - a2_local            = false -> null
              - a2_radius           = false -> null
              - a2_tacacs           = false -> null
              - a3_if_authenticated = false -> null
              - a3_local            = false -> null
              - a3_radius           = false -> null
              - a3_tacacs           = false -> null
              - a4_if_authenticated = false -> null
              - a4_local            = false -> null
              - a4_radius           = false -> null
              - a4_tacacs           = false -> null
              - name                = "default" -> null
            },
        ] -> null
      - id     = "Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization" -> null
    }

  # module.iosxe.iosxe_system.system["xeac-cat8kv-2"] will be destroyed
  - resource "iosxe_system" "system" {
      - device                       = "xeac-cat8kv-2" -> null
      - enable_secret_wo             = (write-only attribute) -> null
      - hostname                     = "xeac-cat8kv-2" -> null
      - id                           = "Cisco-IOS-XE-native:native" -> null
      - ip_http_authentication_local = true -> null
      - ip_http_secure_server        = true -> null
      - ip_http_server               = true -> null
      - ip_routing                   = true -> null
      - ipv6_unicast_routing         = true -> null
    }

  # module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"] will be destroyed
  - resource "iosxe_vrf" "vrf" {
      - description = "VRF for TACACS testing" -> null
      - device      = "xeac-cat8kv-2" -> null
      - id          = "Cisco-IOS-XE-native:native/vrf/definition=TACACS-VRF" -> null
      - name        = "TACACS-VRF" -> null
      - rd          = "65000:100" -> null
    }

  # module.iosxe.module.model.local_sensitive_file.defaults[0] will be destroyed
  - resource "local_sensitive_file" "defaults" {
      - content              = (sensitive value) -> null
      - content_base64sha256 = "BMKfYQMYIL4l6z4OVuBuW8V2KwklU8+/nLVyzSyt+fc=" -> null
      - content_base64sha512 = "Y0rubjX79eczyjozKGcmQooPSe7BNCoqj8K22XPi8dYgaTn3pfCNXtihTtwv+gFWQ/Iyy38ADOsksJfouLM3kQ==" -> null
      - content_md5          = "0de07121cc5891bfb0faeb51b2ea6695" -> null
      - content_sha1         = "8b089d17667d357e48381b85f0efe37c0b238826" -> null
      - content_sha256       = "04c29f61031820be25eb3e0e56e06e5bc5762b092553cfbf9cb572cd2cadf9f7" -> null
      - content_sha512       = "634aee6e35fbf5e733ca3a33286726428a0f49eec1342a2a8fc2b6d973e2f1d6206939f7a5f08d5ed8a14edc2ffa015643f232cb7f000ceb24b097e8b8b33791" -> null
      - directory_permission = "0700" -> null
      - file_permission      = "0700" -> null
      - filename             = "defaults.yaml" -> null
      - id                   = "8b089d17667d357e48381b85f0efe37c0b238826" -> null
    }

  # module.iosxe.module.model.local_sensitive_file.model[0] will be destroyed
  - resource "local_sensitive_file" "model" {
      - content              = (sensitive value) -> null
      - content_base64sha256 = "JrQQRabgOSmkVJv520fWTc9JzoE9WK4gHrpIZ3yy/LQ=" -> null
      - content_base64sha512 = "jlSgLi9gzmAKfbsWQnPm5CQW3m9Aoe3B3PedrqSjfmou5qspAfxsBbtx+OM9K293nO+KUYqAFpYKaFXXCgOtTg==" -> null
      - content_md5          = "2e873bff64359cc9da566dec3863f67e" -> null
      - content_sha1         = "28405f652793bc9121ef0c30cce058cc833d254a" -> null
      - content_sha256       = "26b41045a6e03929a4549bf9db47d64dcf49ce813d58ae201eba48677cb2fcb4" -> null
      - content_sha512       = "8e54a02e2f60ce600a7dbb164273e6e42416de6f40a1edc1dcf79daea4a37e6a2ee6ab2901fc6c05bb71f8e33d2b6f779cef8a518a8016960a6855d70a03ad4e" -> null
      - directory_permission = "0700" -> null
      - file_permission      = "0700" -> null
      - filename             = "model.yaml" -> null
      - id                   = "28405f652793bc9121ef0c30cce058cc833d254a" -> null
    }

Plan: 0 to add, 0 to change, 8 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

module.iosxe.module.model.local_sensitive_file.model[0]: Destroying... [id=28405f652793bc9121ef0c30cce058cc833d254a]
module.iosxe.module.model.local_sensitive_file.defaults[0]: Destroying... [id=8b089d17667d357e48381b85f0efe37c0b238826]
module.iosxe.module.model.local_sensitive_file.defaults[0]: Destruction complete after 0s
module.iosxe.module.model.local_sensitive_file.model[0]: Destruction complete after 0s
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"]: Destroying... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authorization]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"]: Destroying... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:accounting]
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"]: Destroying... [id=Cisco-IOS-XE-native:native/aaa/Cisco-IOS-XE-aaa:authentication]
module.iosxe.iosxe_system.system["xeac-cat8kv-2"]: Destroying... [id=Cisco-IOS-XE-native:native]
module.iosxe.iosxe_aaa_accounting.aaa_accounting["xeac-cat8kv-2"]: Destruction complete after 1s
module.iosxe.iosxe_aaa_authorization.aaa_authorization["xeac-cat8kv-2"]: Destruction complete after 2s
module.iosxe.iosxe_aaa_authentication.aaa_authentication["xeac-cat8kv-2"]: Destruction complete after 3s
module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"]: Destroying... [id=Cisco-IOS-XE-native:native/aaa]
module.iosxe.iosxe_system.system["xeac-cat8kv-2"]: Destruction complete after 5s
module.iosxe.iosxe_aaa.aaa["xeac-cat8kv-2"]: Destruction complete after 4s
module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"]: Destroying... [id=Cisco-IOS-XE-native:native/vrf/definition=TACACS-VRF]
module.iosxe.iosxe_vrf.vrf["xeac-cat8kv-2/TACACS-VRF"]: Destruction complete after 1s

Destroy complete! Resources: 8 destroyed.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~100%
- **AI Reason**: add missing VRF dependency to iosxe_aaa resource