### PR TITLE
feat(interfaces): add PIM support for tunnel interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ module "iosxe" {
 | [iosxe_interface_pim.loopback_pim](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim) | resource |
 | [iosxe_interface_pim.port_channel_pim](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim) | resource |
 | [iosxe_interface_pim.port_channel_subinterface_pim](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim) | resource |
+| [iosxe_interface_pim.tunnel_pim](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim) | resource |
 | [iosxe_interface_pim.vlan_pim](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim) | resource |
 | [iosxe_interface_pim_ipv6.ethernet_pim_ipv6](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim_ipv6) | resource |
 | [iosxe_interface_pim_ipv6.ethernet_pim_ipv6_unmanaged](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim_ipv6) | resource |
 | [iosxe_interface_pim_ipv6.loopback_pim_ipv6](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim_ipv6) | resource |
 | [iosxe_interface_pim_ipv6.port_channel_pim_ipv6](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim_ipv6) | resource |
+| [iosxe_interface_pim_ipv6.tunnel_pim_ipv6](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim_ipv6) | resource |
 | [iosxe_interface_pim_ipv6.vlan_pim_ipv6](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_pim_ipv6) | resource |
 | [iosxe_interface_port_channel.port_channel](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_port_channel) | resource |
 | [iosxe_interface_port_channel_subinterface.port_channel_subinterface](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.16.0/docs/resources/interface_port_channel_subinterface) | resource |

--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -2253,6 +2253,20 @@ locals {
         ospfv3_network_type_point_to_multipoint = try(int.ospfv3.network_type, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ospfv3.network_type, null) == "point-to-multipoint" ? true : null
         ospfv3_network_type_point_to_point      = try(int.ospfv3.network_type, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ospfv3.network_type, null) == "point-to-point" ? true : null
         ospfv3_cost                             = try(int.ospfv3.cost, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ospfv3.cost, null)
+        pim                                     = try(int.pim.passive, int.pim.dense_mode, int.pim.sparse_mode, int.pim.sparse_dense_mode, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.passive, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.dense_mode, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.sparse_mode, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.sparse_dense_mode, null) != null ? true : false
+        pim_passive                             = try(int.pim.passive, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.passive, null)
+        pim_dense_mode                          = try(int.pim.dense_mode, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.dense_mode, null)
+        pim_sparse_mode                         = try(int.pim.sparse_mode, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.sparse_mode, null)
+        pim_sparse_dense_mode                   = try(int.pim.sparse_dense_mode, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.sparse_dense_mode, null)
+        pim_bfd                                 = try(int.pim.bfd, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.bfd, null)
+        pim_border                              = try(int.pim.border, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.border, null)
+        pim_bsr_border                          = try(int.pim.bsr_border, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.bsr_border, null)
+        pim_dr_priority                         = try(int.pim.dr_priority, local.defaults.iosxe.devices.configuration.interfaces.tunnels.pim.dr_priority, null)
+        ipv6_pim                                = try(int.ipv6.pim, null) != null ? true : false
+        ipv6_pim_pim                            = try(int.ipv6.pim.pim, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ipv6.pim.pim, null)
+        ipv6_pim_bfd                            = try(int.ipv6.pim.bfd, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ipv6.pim.bfd, null)
+        ipv6_pim_bsr_border                     = try(int.ipv6.pim.bsr_border, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ipv6.pim.bsr_border, null)
+        ipv6_pim_dr_priority                    = try(int.ipv6.pim.dr_priority, local.defaults.iosxe.devices.configuration.interfaces.tunnels.ipv6.pim.dr_priority, null)
         ip_igmp_version                         = try(int.igmp.version, local.defaults.iosxe.devices.configuration.interfaces.tunnels.igmp.version, null)
       }
     ]
@@ -2358,5 +2372,42 @@ resource "iosxe_interface_ospfv3" "tunnel_ospfv3" {
     iosxe_interface_tunnel.tunnel,
     iosxe_ospf.ospf,
     iosxe_ospf_vrf.ospf_vrf
+  ]
+}
+
+resource "iosxe_interface_pim" "tunnel_pim" {
+  for_each = { for v in local.interfaces_tunnels : v.key => v if v.pim }
+
+  device            = each.value.device
+  type              = "Tunnel"
+  name              = each.value.name
+  passive           = each.value.pim_passive
+  dense_mode        = each.value.pim_dense_mode
+  sparse_mode       = each.value.pim_sparse_mode
+  sparse_dense_mode = each.value.pim_sparse_dense_mode
+  bfd               = each.value.pim_bfd
+  border            = each.value.pim_border
+  bsr_border        = each.value.pim_bsr_border
+  dr_priority       = each.value.pim_dr_priority
+
+  depends_on = [
+    iosxe_system.system,
+    iosxe_interface_tunnel.tunnel
+  ]
+}
+
+resource "iosxe_interface_pim_ipv6" "tunnel_pim_ipv6" {
+  for_each = { for v in local.interfaces_tunnels : v.key => v if v.ipv6_pim }
+
+  device      = each.value.device
+  type        = "Tunnel"
+  name        = each.value.name
+  pim         = each.value.ipv6_pim_pim
+  bfd         = each.value.ipv6_pim_bfd
+  bsr_border  = each.value.ipv6_pim_bsr_border
+  dr_priority = each.value.ipv6_pim_dr_priority
+
+  depends_on = [
+    iosxe_interface_tunnel.tunnel
   ]
 }


### PR DESCRIPTION
## Summary

- Add IPv4 PIM (`iosxe_interface_pim`) and IPv6 PIM (`iosxe_interface_pim_ipv6`) resources for tunnel interfaces
- Add PIM fields (passive, dense_mode, sparse_mode, sparse_dense_mode, bfd, border, bsr_border, dr_priority) and IPv6 PIM fields (pim, bfd, bsr_border, dr_priority) to `interfaces_tunnels` locals
- Follows the same pattern already established for loopbacks, VLANs, ethernets, port-channels, and port-channel subinterfaces

The `iosxe_interface_pim` Terraform provider resource already supports `Tunnel` as an interface type — this change wires it into the NaC module.

## Testing

This change was tested and confirmed working with the following data model:

```yaml
---
iosxe:
  devices:
    - name: xeac-cat8kv-1
      host: 192.0.2.10
      protocol: restconf
      configuration:
        interfaces:
          tunnels:
            - name: 100
              description: "PIM sparse-mode with all flags"
              tunnel_source: Loopback100
              tunnel_destination_ipv4: 10.255.255.1
              ipv4:
                address: 10.100.200.1
                address_mask: 255.255.255.252
              pim:
                sparse_mode: true
                bfd: true
                border: true
                bsr_border: true
                dr_priority: 100
            - name: 101
              description: "PIM dense-mode with IPv6 PIM"
              tunnel_source: Loopback100
              tunnel_destination_ipv4: 10.255.255.2
              ipv4:
                address: 10.100.200.5
                address_mask: 255.255.255.252
              ipv6:
                enable: true
                addresses:
                  - prefix: 2001:db8:100::1/64
                pim:
                  pim: true
                  bfd: true
                  bsr_border: true
                  dr_priority: 200
              pim:
                dense_mode: true
            - name: 102
              description: "PIM passive"
              tunnel_source: Loopback100
              tunnel_destination_ipv4: 10.255.255.3
              ipv4:
                address: 10.100.200.9
                address_mask: 255.255.255.252
              pim:
                passive: true
            - name: 103
              description: "PIM sparse-dense-mode"
              tunnel_source: Loopback100
              tunnel_destination_ipv4: 10.255.255.4
              ipv4:
                address: 10.100.200.13
                address_mask: 255.255.255.252
              pim:
                sparse_dense_mode: true
        system:
          hostname: xeac-cat8kv-1
          http:
            server: true
            secure_server: true
            authentication_local: true
```

Applying this data model to the target device resulted in the below (correct) configuration:

```
xeac-cat8kv-1#show running-config interface Tunnel100
Building configuration...

Current configuration : 247 bytes
!
interface Tunnel100
 description PIM sparse-mode with all flags
 ip address 10.100.200.1 255.255.255.252
 ip pim dr-priority 100
 ip pim bsr-border
 ip pim sparse-mode
 ip pim bfd
 tunnel source Loopback100
 tunnel destination 10.255.255.1
end

xeac-cat8kv-1#show running-config interface Tunnel101
Building configuration...

Current configuration : 296 bytes
!
interface Tunnel101
 description PIM dense-mode with IPv6 PIM
 ip address 10.100.200.5 255.255.255.252
 ip pim dense-mode
 ipv6 address 2001:DB8:100::1/64
 ipv6 enable
 ipv6 pim dr-priority 200
 ipv6 pim bsr border
 ipv6 pim bfd
 tunnel source Loopback100
 tunnel destination 10.255.255.2
end

xeac-cat8kv-1#show running-config interface Tunnel102
Building configuration...

Current configuration : 169 bytes
!
interface Tunnel102
 description PIM passive
 ip address 10.100.200.9 255.255.255.252
 ip pim passive
 tunnel source Loopback100
 tunnel destination 10.255.255.3
end

xeac-cat8kv-1#show running-config interface Tunnel103
Building configuration...

Current configuration : 190 bytes
!
interface Tunnel103
 description PIM sparse-dense-mode
 ip address 10.100.200.13 255.255.255.252
 ip pim sparse-dense-mode
 tunnel source Loopback100
 tunnel destination 10.255.255.4
end
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~100%
- **AI Reason**: tunnel PIM locals + resources
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart