### PR TITLE
feat(license): remove obsolete feature_* attribute mappings

### DIFF
--- a/iosxe_license.tf
+++ b/iosxe_license.tf
@@ -13,9 +13,4 @@ resource "iosxe_license" "license" {
   accept_user                         = try(local.device_config[each.value.name].license.accept_user, local.defaults.iosxe.configuration.license.accept_user, null)
   udi_pid                             = try(local.device_config[each.value.name].license.udi_pid, local.defaults.iosxe.configuration.license.udi_pid, null)
   udi_sn                              = try(local.device_config[each.value.name].license.udi_sn, local.defaults.iosxe.configuration.license.udi_sn, null)
-  feature_name                        = try(local.device_config[each.value.name].license.feature_name, local.defaults.iosxe.configuration.license.feature_name, null)
-  feature_port_bulk                   = try(local.device_config[each.value.name].license.feature_port_bulk, local.defaults.iosxe.configuration.license.feature_port_bulk, null)
-  feature_port_onegig                 = try(local.device_config[each.value.name].license.feature_port_onegig, local.defaults.iosxe.configuration.license.feature_port_onegig, null)
-  feature_port_b_6xonegig             = try(local.device_config[each.value.name].license.feature_port_b_6xonegig, local.defaults.iosxe.configuration.license.feature_port_b_6xonegig, null)
-  feature_port_tengig                 = try(local.device_config[each.value.name].license.feature_port_tengig, local.defaults.iosxe.configuration.license.feature_port_tengig, null)
 }


### PR DESCRIPTION
## Summary

- Remove `feature_name`, `feature_port_bulk`, `feature_port_onegig`, `feature_port_b_6xonegig`, and `feature_port_tengig` mappings from `iosxe_license` resource in `iosxe_license.tf`
- These attributes map to YANG leafs with no backing CLI on any supported IOS-XE platform or version (17.12.x+)
- Corresponding provider attributes removed in CiscoDevNet/terraform-provider-iosxe#469

## Breaking Change

Users with any of the five `feature_*` attributes in their NaC data model will get Terraform plan errors after upgrading the provider. Since these attributes never functioned on any device, removing them from the data model is the correct remediation.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~100%
- **AI Reason**: remove obsolete license feature_* attribute mappings
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart