### PR TITLE
fix(class_map): split nested class-maps into separate resource for dependency ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ module "iosxe" {
 | [iosxe_bridge_domain.bridge_domain](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/bridge_domain) | resource |
 | [iosxe_cdp.cdp](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/cdp) | resource |
 | [iosxe_class_map.class_map](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/class_map) | resource |
+| [iosxe_class_map.class_map_nested](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/class_map) | resource |
 | [iosxe_cli.cli_0](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/cli) | resource |
 | [iosxe_cli.cli_1](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/cli) | resource |
 | [iosxe_cli.cli_2](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/cli) | resource |

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -52,7 +52,7 @@ locals {
 }
 
 resource "iosxe_class_map" "class_map" {
-  for_each = { for e in local.class_maps : e.key => e }
+  for_each = { for e in local.class_maps : e.key => e if e.match_class_map == null }
   device   = each.value.device
 
   name                                           = each.value.name
@@ -80,6 +80,41 @@ resource "iosxe_class_map" "class_map" {
   match_protocol                                 = each.value.match_protocol
   match_class_map                                = each.value.match_class_map
   description                                    = each.value.description
+}
+
+resource "iosxe_class_map" "class_map_nested" {
+  for_each = { for e in local.class_maps : e.key => e if e.match_class_map != null }
+  device   = each.value.device
+
+  name                                           = each.value.name
+  type                                           = each.value.type
+  subscriber                                     = each.value.subscriber
+  prematch                                       = each.value.prematch
+  match_authorization_status_authorized          = each.value.match_authorization_status_authorized
+  match_result_type_aaa_timeout                  = each.value.match_result_type_aaa_timeout
+  match_result_type_success                      = each.value.match_result_type_success
+  match_authorization_status_unauthorized        = each.value.match_authorization_status_unauthorized
+  match_activated_service_templates              = each.value.match_activated_service_templates
+  match_authorizing_method_priority_greater_than = each.value.match_authorizing_method_priority_greater_than
+  match_method_dot1x                             = each.value.match_method_dot1x
+  match_result_type_method_dot1x_authoritative   = each.value.match_result_type_method_dot1x_authoritative
+  match_result_type_method_dot1x_agent_not_found = each.value.match_result_type_method_dot1x_agent_not_found
+  match_result_type_method_dot1x_method_timeout  = each.value.match_result_type_method_dot1x_method_timeout
+  match_method_mab                               = each.value.match_method_mab
+  match_result_type_method_mab_authoritative     = each.value.match_result_type_method_mab_authoritative
+  match_dscp                                     = each.value.match_dscp
+  match_access_group_index_legacy                = each.value.match_access_group_index_legacy
+  match_access_group_index_list                  = each.value.match_access_group_index_list
+  match_access_group_name                        = each.value.match_access_group_name
+  match_ip_dscp                                  = each.value.match_ip_dscp
+  match_ip_precedence                            = each.value.match_ip_precedence
+  match_protocol                                 = each.value.match_protocol
+  match_class_map                                = each.value.match_class_map
+  description                                    = each.value.description
+
+  depends_on = [
+    iosxe_class_map.class_map
+  ]
 }
 
 locals {
@@ -150,7 +185,8 @@ resource "iosxe_policy_map" "policy_map" {
   classes     = each.value.classes
 
   depends_on = [
-    iosxe_class_map.class_map
+    iosxe_class_map.class_map,
+    iosxe_class_map.class_map_nested
   ]
 }
 


### PR DESCRIPTION
## Summary

- Split `iosxe_class_map` into two resource blocks: `class_map` (leaf) and `class_map_nested` (references sibling class-maps via `match_class_map`)
- `class_map_nested` has `depends_on = [iosxe_class_map.class_map]` to prevent parallel-apply race
- Updated `iosxe_policy_map` `depends_on` to wait for both

## Context

When Terraform creates both the referenced and referencing class-maps in parallel, the device returns `data-missing` because the target doesn't exist yet. Splitting into leaf/nested stages expresses the dependency in Terraform's graph directly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: module fix for class-map ordering race
- **Human Oversight**: Code reviewed and approved by chart2