### PR TITLE
feat(spanning_tree): expand VLAN ranges into individual provider entries

### DIFF
--- a/iosxe_spanning_tree.tf
+++ b/iosxe_spanning_tree.tf
@@ -20,10 +20,18 @@ resource "iosxe_spanning_tree" "spanning_tree" {
     )
   }]
 
-  vlans = try(length(local.device_config[each.value.name].spanning_tree.vlans) == 0, true) ? null : [for v in try(local.device_config[each.value.name].spanning_tree.vlans, local.defaults.iosxe.configuration.spanning_tree.vlans, []) : {
-    id       = try(tostring(v.id), local.defaults.iosxe.configuration.spanning_tree.vlans.id, null)
-    priority = try(v.priority, local.defaults.iosxe.configuration.spanning_tree.vlans.priority, null)
-  }]
+  vlans = try(length(local.device_config[each.value.name].spanning_tree.vlans) == 0, true) ? null : flatten([
+    for v in try(local.device_config[each.value.name].spanning_tree.vlans, local.defaults.iosxe.configuration.spanning_tree.vlans, []) : [
+      for id in(
+        try(v.vlans, null) != null
+        ? provider::utils::normalize_vlans(v.vlans, "list")
+        : [try(v.id, local.defaults.iosxe.configuration.spanning_tree.vlans.id)]
+        ) : {
+        id       = tostring(id)
+        priority = try(v.priority, local.defaults.iosxe.configuration.spanning_tree.vlans.priority, null)
+      }
+    ]
+  ])
 
   disabled_vlans = try(local.device_config[each.value.name].spanning_tree.disabled.vlans, null) == null ? null : [
     for id in provider::utils::normalize_vlans(


### PR DESCRIPTION
## Summary

The `vlans` block in `iosxe_spanning_tree.tf` now supports entries with a `vlans` key (general_vlans structure with ids/ranges) in addition to the existing `id` key. Ranges are expanded into individual per-VLAN entries using `provider::utils::normalize_vlans`, the same pattern already used by `disabled_vlans` and `mst_instances`.

## Example

Data model input:
```yaml
spanning_tree:
  vlans:
    - id: 100
      priority: 4096
    - vlans:
        ranges:
          - from: 200
            to: 203
      priority: 8192
```

Terraform plan output (5 individual entries):
```hcl
vlans = [
  { id = "100", priority = 4096 },
  { id = "200", priority = 8192 },
  { id = "201", priority = 8192 },
  { id = "202", priority = 8192 },
  { id = "203", priority = 8192 },
]
```

## Changes

- `iosxe_spanning_tree.tf`: Changed `vlans` from direct passthrough to `flatten()` + double `for` with `normalize_vlans` expansion

Backward compatible — entries with `id` (no `vlans`) produce a single entry as before.

## Validation

Tested on live Cat8000v (17.15) — all 5 VLANs created with correct priorities.

Companion PRs:
- nac-iosxe schema: netascode/nac-iosxe#1415
- nac-tool mapping: netascode/nac-tool branch `fix/spanning-tree-vlan-range-mapping`

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~85%
- **AI Reason**: expand STP VLAN ranges via normalize_vlans
- **Human Oversight**: Code reviewed and approved by ChristopherJHart