### PR TITLE
fix(access_list_extended): add depends_on for object_group

### DIFF
--- a/iosxe_access_lists.tf
+++ b/iosxe_access_lists.tf
@@ -113,6 +113,8 @@ resource "iosxe_access_list_extended" "access_list_extended" {
 
   name    = each.value.name
   entries = each.value.entries
+
+  depends_on = [iosxe_object_group.object_group]
 }
 
 locals {


### PR DESCRIPTION
## Summary

- Add explicit `depends_on` from `iosxe_access_list_extended` to `iosxe_object_group` to enforce correct apply/destroy ordering

## Notes

- ACL entries reference object-group names as plain strings (`source_object_group`, `destination_object_group`), so Terraform cannot infer resource dependency from references
- Without the dependency, apply may push ACLs before object-groups exist, and destroy may delete object-groups before ACL references are removed
- Both cases produce `illegal reference` / `[type=application, tag=data-missing]` errors from the device
- Follows the same pattern as #313 (`interface_tunnel` → `flow_monitor`) and #310 (`zone_pair_security` → `zone_security`)

## Test Evidence

### Data Model

Deployed to **xeac-cat8kv** (192.0.2.1), IOS-XE 17.15.5:

```yaml
iosxe:
  devices:
    - name: xeac-cat8kv
      host: 192.0.2.1
      protocol: netconf
      configuration:
        object_groups_network:
          - name: OG_SRC_1411
            network_addresses:
              - address: 10.0.0.0
                mask: 255.255.255.0
          - name: OG_DST_1411
            network_addresses:
              - address: 10.0.1.0
                mask: 255.255.255.0
        access_lists:
          extended:
            - name: ACL-OG-TEST-1411
              entries:
                - sequence: 10
                  action: permit
                  protocol: ip
                  source:
                    object_group: OG_SRC_1411
                  destination:
                    object_group: OG_DST_1411
```

### Terraform Apply

Object group is created first, ACL starts only after object group completes:

```
module.iosxe.iosxe_object_group.object_group["xeac-cat8kv"]: Creating...
module.iosxe.iosxe_object_group.object_group["xeac-cat8kv"]: Creation complete after 2s
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv/ACL-OG-TEST-1411"]: Creating...
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv/ACL-OG-TEST-1411"]: Creation complete after 1s

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

### Terraform Destroy

ACL is destroyed first, object group starts only after ACL removal completes:

```
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv/ACL-OG-TEST-1411"]: Destroying...
module.iosxe.iosxe_access_list_extended.access_list_extended["xeac-cat8kv/ACL-OG-TEST-1411"]: Destruction complete after 3s
module.iosxe.iosxe_object_group.object_group["xeac-cat8kv"]: Destroying...
module.iosxe.iosxe_object_group.object_group["xeac-cat8kv"]: Destruction complete after 0s

Destroy complete! Resources: 4 destroyed.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~100%
- **AI Reason**: depends_on fix for ordering bug
- **Human Oversight**: Reproduced on live device, verified fix on live device