### PR TITLE
feat(iosxe): add binding_reachable_lifetime to device_tracking module

### DIFF
--- a/iosxe_device_tracking.tf
+++ b/iosxe_device_tracking.tf
@@ -7,6 +7,7 @@ resource "iosxe_device_tracking" "device_tracking" {
   tracking_auto_source_fallback_mask     = try(local.device_config[each.value.name].device_tracking.tracking_auto_source_fallback_mask, local.defaults.iosxe.configuration.device_tracking.tracking_auto_source_fallback_mask, null)
   tracking_auto_source_fallback_override = try(local.device_config[each.value.name].device_tracking.tracking_auto_source_fallback_override, local.defaults.iosxe.configuration.device_tracking.tracking_auto_source_fallback_override, null)
   tracking_retry_interval                = try(local.device_config[each.value.name].device_tracking.tracking_retry_interval, local.defaults.iosxe.configuration.device_tracking.tracking_retry_interval, null)
+  binding_reachable_lifetime             = try(local.device_config[each.value.name].device_tracking.binding_reachable_lifetime, local.defaults.iosxe.configuration.device_tracking.binding_reachable_lifetime, null)
 }
 
 locals {


### PR DESCRIPTION
## Summary
- Add `binding_reachable_lifetime` attribute mapping to the `iosxe_device_tracking` resource in the module

## Notes
- Maps `device_tracking.binding_reachable_lifetime` from the NaC data model to the provider attribute
- Tested on IOS-XE 17.15.1a (Cat8kv)

## Test Evidence

### Data Model

Deployed to **xeac-cat8kv-1** (192.0.2.1), IOS-XE 17.15.1a:

```yaml
iosxe:
  devices:
    - name: xeac-cat8kv-1
      host: 192.0.2.1
      protocol: restconf
      configuration:
        device_tracking:
          binding_reachable_lifetime: 7200
```

### Terraform Apply

```
module.iosxe.iosxe_device_tracking.device_tracking["xeac-cat8kv-1"]: Creating...
module.iosxe.iosxe_device_tracking.device_tracking["xeac-cat8kv-1"]: Creation complete after 0s [id=Cisco-IOS-XE-native:native/device-tracking]

Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
```

### Device Running-Config

```
device-tracking binding reachable-lifetime 7200
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: module attribute addition
- **Human Oversight**: Code reviewed and approved by chart2