### PR TITLE
feat(line): add password attributes to aux entries

### DIFF
--- a/iosxe_line.tf
+++ b/iosxe_line.tf
@@ -57,6 +57,9 @@ resource "iosxe_line" "line" {
     exec_timeout_seconds  = try(a.exec_timeout_seconds, local.defaults.iosxe.configuration.line.auxes.exec_timeout_seconds, null)
     monitor               = try(a.monitor, local.defaults.iosxe.configuration.line.auxes.monitor, null)
     stopbits              = try(a.stopbits, local.defaults.iosxe.configuration.line.auxes.stopbits, null)
+    password              = try(a.password, local.defaults.iosxe.configuration.line.auxes.password, null)
+    password_level        = try(a.password_level, local.defaults.iosxe.configuration.line.auxes.password_level, null)
+    password_type         = try(a.password_type, local.defaults.iosxe.configuration.line.auxes.password_type, null)
     escape_character      = try(a.escape_character, local.defaults.iosxe.configuration.line.auxes.escape_character, null)
     logging_synchronous   = try(a.logging_synchronous, local.defaults.iosxe.configuration.line.auxes.logging_synchronous, null)
     transport_output_none = contains(try(a.transport_output, local.defaults.iosxe.configuration.line.auxes.transport_output, []), "none") ? true : null


### PR DESCRIPTION
## Summary
- Add `password`, `password_level`, and `password_type` mappings to the aux block in `iosxe_line.tf`
- Mirrors the existing console password attribute pattern (lines 11-13)

## Notes
- Attribute ordering follows the same convention as console: password, password_level, password_type

## Test Evidence

### Data Model

Deployed to **xeac-cat8kv-1** (192.0.2.1), IOS-XE 17.15.1:

```yaml
iosxe:
  devices:
    - name: xeac-cat8kv-1
      configuration:
        line:
          auxes:
            - number: 0
              password_level: 7
              password_type: '7'
              password: 0822455D0A16
```

### Terraform Apply

```
module.iosxe.iosxe_line.line["xeac-cat8kv-1"]: Creating...
module.iosxe.iosxe_line.line["xeac-cat8kv-1"]: Creation complete after 1s [id=Cisco-IOS-XE-native:native/line]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Device Running-Config

```
line aux 0
 password level 7 7 0822455D0A16
```

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: attribute addition to module HCL