### PR TITLE
feat(iosxe): add privilege level command mapping module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ module "iosxe" {
 | [iosxe_policy_map.policy_map](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/policy_map) | resource |
 | [iosxe_policy_map_event.policy_map_event](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/policy_map_event) | resource |
 | [iosxe_prefix_list.prefix_list](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/prefix_list) | resource |
+| [iosxe_privilege.privilege](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/privilege) | resource |
 | [iosxe_radius.radius](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/radius) | resource |
 | [iosxe_radius_server.radius_server](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/radius_server) | resource |
 | [iosxe_route_map.route_map](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/route_map) | resource |

--- a/iosxe_privilege.tf
+++ b/iosxe_privilege.tf
@@ -1,0 +1,25 @@
+locals {
+  privilege_modes = flatten([
+    for device in local.devices : [
+      for mode in distinct([for m in try(local.device_config[device.name].aaa.privilege_command_mappings, []) : m.mode]) : {
+        key    = format("%s/%s", device.name, mode)
+        device = device.name
+        name   = mode
+        levels = [for m in try(local.device_config[device.name].aaa.privilege_command_mappings, []) : {
+          level = m.level
+          commands = [for c in try(m.commands, []) : {
+            command = c
+          }]
+        } if m.mode == mode]
+      }
+    ]
+  ])
+}
+
+resource "iosxe_privilege" "privilege" {
+  for_each = { for e in local.privilege_modes : e.key => e }
+  device   = each.value.device
+
+  name   = each.value.name
+  levels = each.value.levels
+}


### PR DESCRIPTION
## Summary
- Add `iosxe_privilege.tf` to surface privilege level command authorization through the NaC module
- Groups privilege_command_mappings by mode to produce one provider resource per mode with nested levels and commands

## Notes
- Depends on `iosxe_privilege` provider resource (PR pending in terraform-provider-iosxe)
- The module groups entries from `aaa.privilege_command_mappings[]` by mode, producing one `iosxe_privilege` resource per distinct mode value

## Test Evidence

### Data Model

Deployed to **xeac-cat8kv-1** (192.0.2.1), IOS-XE 17.15.1a:

```yaml
aaa:
  privilege_command_mappings:
    - mode: exec
      level: 7
      commands:
        - show running-config
        - show interfaces
    - mode: exec
      level: 5
      commands:
        - ping
```

### Terraform Apply

```
module.iosxe.iosxe_privilege.privilege["xeac-cat8kv-1/exec"]: Creating...
module.iosxe.iosxe_privilege.privilege["xeac-cat8kv-1/exec"]: Creation complete

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Device Running-Config

```
privilege exec level 5 ping
privilege exec level 7 show running-config
privilege exec level 7 show interfaces
privilege exec level 7 show
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~80%
- **AI Reason**: module HCL implementation + testing
- **Human Oversight**: Code reviewed and approved by chart2