### PR TITLE
feat(iosxe): add crypto_pki_certificate_pool module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ module "iosxe" {
 | [iosxe_crypto_ipsec_profile.crypto_ipsec_profile](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/crypto_ipsec_profile) | resource |
 | [iosxe_crypto_ipsec_transform_set.crypto_ipsec_transform_set](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/crypto_ipsec_transform_set) | resource |
 | [iosxe_crypto_pki.crypto_pki](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/crypto_pki) | resource |
+| [iosxe_crypto_pki_certificate_pool.crypto_pki_certificate_pool](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/crypto_pki_certificate_pool) | resource |
 | [iosxe_cts.cts](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/cts) | resource |
 | [iosxe_device_sensor.device_sensor](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/device_sensor) | resource |
 | [iosxe_device_tracking.device_tracking](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/device_tracking) | resource |

--- a/iosxe_crypto.tf
+++ b/iosxe_crypto.tf
@@ -316,3 +316,10 @@ resource "iosxe_crypto" "crypto_engine" {
 
   engine_compliance_shield_disable = try(local.device_config[each.value.name].crypto.engine.compliance_shield_disable, local.defaults.iosxe.configuration.crypto.engine.compliance_shield_disable, null)
 }
+
+resource "iosxe_crypto_pki_certificate_pool" "crypto_pki_certificate_pool" {
+  for_each = { for device in local.devices : device.name => device if try(local.device_config[device.name].crypto.pki.certificate_pool, null) != null }
+  device   = each.value.name
+
+  cabundle = try(local.device_config[each.value.name].crypto.pki.certificate_pool.cabundle, local.defaults.iosxe.configuration.crypto.pki.certificate_pool.cabundle, null)
+}


### PR DESCRIPTION
## Summary
- Add Terraform module resource mapping for `iosxe_crypto_pki_certificate_pool`
- Maps `crypto.pki.certificate_pool.cabundle` from the NaC data model to the provider resource

## Notes
- Requires the provider PR (CiscoDevNet/terraform-provider-iosxe#568) to be merged first
- The resource is a per-device singleton (presence container), not a list
- The `cabundle` attribute is read/import-only via RESTCONF — initial configuration must be done via CLI. The provider correctly reads and detects drift on the value.

## Test Evidence

### Data Model

Deployed to **xeac-cat8kv-1** (192.0.2.1), IOS-XE 17.15.1a:

```yaml
iosxe:
  devices:
    - name: xeac-cat8kv-1
      configuration:
        crypto:
          pki:
            certificate_pool:
              cabundle: "nvram:test_bundle.p7b"
```

### Terraform Import (after CLI configuration of cabundle)

```
terraform import '...crypto_pki_certificate_pool["xeac-cat8kv-1"]' "xeac-cat8kv-1"
Import successful!
```

### No-Drift Verification

```
No changes. Your infrastructure matches the configuration.
```

### Device Running-Config (configured via CLI)

```
crypto pki certificate pool
 cabundle nvram:test_bundle.p7b
```

### RESTCONF Read Confirmation

```json
{
    "Cisco-IOS-XE-crypto:pool": {
        "cabundle": "nvram:test_bundle.p7b"
    }
}
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: module resource mapping