### PR TITLE
fix(vlan): split private_vlan_association into separate resource for dependency ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ module "iosxe" {
 | [iosxe_udld.udld](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/udld) | resource |
 | [iosxe_username.username](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/username) | resource |
 | [iosxe_vlan.vlan](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/vlan) | resource |
+| [iosxe_vlan.vlan_private_association](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/vlan) | resource |
 | [iosxe_vlan_access_map.vlan_access_map](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/vlan_access_map) | resource |
 | [iosxe_vlan_configuration.vlan_configuration](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/vlan_configuration) | resource |
 | [iosxe_vlan_filter.vlan_filter](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/vlan_filter) | resource |

--- a/iosxe_vlan.tf
+++ b/iosxe_vlan.tf
@@ -2,16 +2,15 @@ locals {
   vlans = flatten([
     for device in local.devices : [
       for vlan in try(local.device_config[device.name].vlan.vlans, []) : {
-        key                      = format("%s/%s", device.name, vlan.id)
-        device                   = device.name
-        id                       = try(vlan.id, local.defaults.iosxe.configuration.vlan.vlans.id, null)
-        name                     = try(vlan.name, local.defaults.iosxe.configuration.vlan.vlans.name, null)
-        private_vlan_association = try(vlan.private_vlan_association, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_association, null)
-        private_vlan_community   = try(vlan.private_vlan_community, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_community, null)
-        private_vlan_isolated    = try(vlan.private_vlan_isolated, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_isolated, null)
-        private_vlan_primary     = try(vlan.private_vlan_primary, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_primary, null)
-        remote_span              = try(vlan.remote_span, local.defaults.iosxe.configuration.vlan.vlans.remote_span, null)
-        shutdown                 = try(vlan.shutdown, local.defaults.iosxe.configuration.vlan.vlans.shutdown, null)
+        key                    = format("%s/%s", device.name, vlan.id)
+        device                 = device.name
+        id                     = try(vlan.id, local.defaults.iosxe.configuration.vlan.vlans.id, null)
+        name                   = try(vlan.name, local.defaults.iosxe.configuration.vlan.vlans.name, null)
+        private_vlan_community = try(vlan.private_vlan_community, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_community, null)
+        private_vlan_isolated  = try(vlan.private_vlan_isolated, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_isolated, null)
+        private_vlan_primary   = try(vlan.private_vlan_primary, local.defaults.iosxe.configuration.vlan.vlans.private_vlan_primary, null)
+        remote_span            = try(vlan.remote_span, local.defaults.iosxe.configuration.vlan.vlans.remote_span, null)
+        shutdown               = try(vlan.shutdown, local.defaults.iosxe.configuration.vlan.vlans.shutdown, null)
       }
     ]
   ])
@@ -21,14 +20,36 @@ resource "iosxe_vlan" "vlan" {
   for_each = { for e in local.vlans : e.key => e }
   device   = each.value.device
 
+  vlan_id                = each.value.id
+  name                   = each.value.name
+  private_vlan_community = each.value.private_vlan_community
+  private_vlan_isolated  = each.value.private_vlan_isolated
+  private_vlan_primary   = each.value.private_vlan_primary
+  remote_span            = each.value.remote_span
+  shutdown               = each.value.shutdown
+}
+
+locals {
+  vlan_private_associations = flatten([
+    for device in local.devices : [
+      for vlan in try(local.device_config[device.name].vlan.vlans, []) : {
+        key                      = format("%s/%s", device.name, vlan.id)
+        device                   = device.name
+        id                       = vlan.id
+        private_vlan_association = try(vlan.private_vlan_association, null)
+      } if try(vlan.private_vlan_association, null) != null
+    ]
+  ])
+}
+
+resource "iosxe_vlan" "vlan_private_association" {
+  for_each = { for e in local.vlan_private_associations : e.key => e }
+  device   = each.value.device
+
   vlan_id                  = each.value.id
-  name                     = each.value.name
   private_vlan_association = each.value.private_vlan_association
-  private_vlan_community   = each.value.private_vlan_community
-  private_vlan_isolated    = each.value.private_vlan_isolated
-  private_vlan_primary     = each.value.private_vlan_primary
-  remote_span              = each.value.remote_span
-  shutdown                 = each.value.shutdown
+
+  depends_on = [iosxe_vlan.vlan]
 }
 
 locals {


### PR DESCRIPTION
## Summary

Splits `private_vlan_association` out of the `iosxe_vlan.vlan` resource into a dedicated `iosxe_vlan.vlan_private_association` resource with `depends_on = [iosxe_vlan.vlan]`. This ensures all base VLANs (including secondary community/isolated VLANs) are created before the primary VLAN's private VLAN association is configured.

Closes CiscoDevNet/terraform-provider-iosxe#254

### Problem

When configuring private VLANs in a single `terraform apply`, the device rejects the `private-vlan association` command if the referenced secondary VLANs don't yet exist. Because all VLANs are created in parallel within the same `for_each` resource, there is no ordering guarantee — the primary VLAN's association can race ahead of the secondary VLANs being provisioned.

### Fix

Follows the same pattern already used for `iosxe_vlan_configuration` (EVPN dependencies): a second resource targeting the same YANG path that only patches `private_vlan_association` after all base VLANs exist. This works because the provider's `no_delete_attributes: true` setting ensures the second resource only sets the specified attribute without overwriting the base VLAN.

## Test Results

**Data Model:**
```yaml
iosxe:
  devices:
    - name: Switch1
      host: 192.0.2.60
      configuration:
        vlan:
          vlans:
            - id: 201
              private_vlan_community: true
              shutdown: false
            - id: 202
              private_vlan_isolated: true
              shutdown: false
            - id: 200
              private_vlan_primary: true
              private_vlan_association: "201,202"
              shutdown: false
```

**Before fix (fails):**
```
module.iosxe.iosxe_vlan.vlan["Switch1/202"]: Creating...
module.iosxe.iosxe_vlan.vlan["Switch1/200"]: Creating...
module.iosxe.iosxe_vlan.vlan["Switch1/201"]: Creating...

Error: Client Error
  with module.iosxe.iosxe_vlan.vlan["Switch1/200"],

  failed to edit config: operation failed
  [1] inconsistent value: Device refused one or more commands
      private-vlan association 201,202
      %Command rejected: invalid private vlan association between vlan200 and
      vlan201. VLAN 201 data is not available.
```

**After fix (succeeds on first apply):**
```
module.iosxe.iosxe_vlan.vlan["Switch1/202"]: Creating...
module.iosxe.iosxe_vlan.vlan["Switch1/200"]: Creating...
module.iosxe.iosxe_vlan.vlan["Switch1/201"]: Creating...
module.iosxe.iosxe_vlan.vlan["Switch1/200"]: Creation complete after 0s
module.iosxe.iosxe_vlan.vlan["Switch1/201"]: Creation complete after 1s
module.iosxe.iosxe_vlan.vlan["Switch1/202"]: Creation complete after 1s
module.iosxe.iosxe_vlan.vlan_private_association["Switch1/200"]: Creating...
module.iosxe.iosxe_vlan.vlan_private_association["Switch1/200"]: Creation complete after 0s

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
```

**Idempotency (second apply):**
```
No changes. Your infrastructure matches the configuration.
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```