### PR TITLE
fix(policy_map): order hierarchical service-policy references

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ module "iosxe" {
 | [iosxe_pim_ipv6.pim_ipv6](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/pim_ipv6) | resource |
 | [iosxe_platform.platform](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/platform) | resource |
 | [iosxe_policy_map.policy_map](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/policy_map) | resource |
+| [iosxe_policy_map.policy_map_nested](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/policy_map) | resource |
 | [iosxe_policy_map_event.policy_map_event](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/policy_map_event) | resource |
 | [iosxe_prefix_list.prefix_list](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/prefix_list) | resource |
 | [iosxe_radius.radius](https://registry.terraform.io/providers/CiscoDevNet/iosxe/0.18.0/docs/resources/radius) | resource |

--- a/iosxe_policy.tf
+++ b/iosxe_policy.tf
@@ -127,6 +127,12 @@ locals {
         type        = try(policy_map.type, local.defaults.iosxe.configuration.policy.policy_maps.type, null)
         subscriber  = try(policy_map.subscriber, local.defaults.iosxe.configuration.policy.policy_maps.subscriber, null)
         description = try(policy_map.description, local.defaults.iosxe.configuration.policy.policy_maps.description, null)
+        has_service_policy = try(length(flatten([
+          for class in policy_map.classes : [
+            for action in class.actions : action.service_policy
+            if try(action.service_policy, null) != null
+          ]
+        ])) > 0, false)
         classes = try(length(policy_map.classes) == 0, true) ? null : [for class in policy_map.classes : {
           name                 = try(class.name, local.defaults.iosxe.configuration.policy.policy_maps.classes.name, null)
           class_type           = try(class.type, local.defaults.iosxe.configuration.policy.policy_maps.classes.type, null)
@@ -175,7 +181,7 @@ locals {
 }
 
 resource "iosxe_policy_map" "policy_map" {
-  for_each = { for e in local.policy_maps : e.key => e }
+  for_each = { for e in local.policy_maps : e.key => e if !e.has_service_policy }
   device   = each.value.device
 
   name        = each.value.name
@@ -188,6 +194,24 @@ resource "iosxe_policy_map" "policy_map" {
     iosxe_class_map.class_map,
     iosxe_class_map.class_map_nested,
     iosxe_parameter_map.parameter_map
+  ]
+}
+
+resource "iosxe_policy_map" "policy_map_nested" {
+  for_each = { for e in local.policy_maps : e.key => e if e.has_service_policy }
+  device   = each.value.device
+
+  name        = each.value.name
+  type        = each.value.type
+  subscriber  = each.value.subscriber
+  description = each.value.description
+  classes     = each.value.classes
+
+  depends_on = [
+    iosxe_class_map.class_map,
+    iosxe_class_map.class_map_nested,
+    iosxe_parameter_map.parameter_map,
+    iosxe_policy_map.policy_map
   ]
 }
 
@@ -262,6 +286,7 @@ resource "iosxe_policy_map_event" "policy_map_event" {
   class_numbers = each.value.class_numbers
 
   depends_on = [
-    iosxe_policy_map.policy_map
+    iosxe_policy_map.policy_map,
+    iosxe_policy_map.policy_map_nested
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a deployment-ordering bug for hierarchical QoS, where a parent policy-map references a child policy-map through a `service-policy` action.

All `iosxe_policy_map` instances were created from a single `for_each` block. Terraform creates `for_each` instances in parallel, so the device could receive the parent policy-map before the referenced child was committed. The device then rejects the parent with a `data-missing` leafref error:

```
illegal reference .../policy-map[name='PARENT-SHAPE']/class[name='class-default']/action-list[action-type='service-policy']/service-policy
[type=application, tag=data-missing]
```

## Fix

Split policy-maps that contain a `service-policy` action into a separate `iosxe_policy_map.policy_map_nested` resource that `depends_on` the base `iosxe_policy_map.policy_map`. Children (which have no `service-policy` action) are created first; parents that reference them are created afterward.

This mirrors the existing `iosxe_class_map.class_map` / `iosxe_class_map.class_map_nested` pattern already used in this file for nested class-maps, so the approach is consistent with the module's established design.

## Verification

Deployed against an IOS-XE device (17.x) with a parent/child policy-map pair:

- `terraform apply` — child `CHILD-QOS` is committed before parent `PARENT-SHAPE`; apply completes cleanly (previously failed)
- The policy-map resources are stable on re-apply (no drift)
- `terraform destroy` — clean teardown

### Minimal reproducer

```yaml
policy:
  policy_maps:
    - name: CHILD-QOS
      classes:
        - name: CM-VOICE
          actions:
            - type: priority
              priority_level: 1
    - name: PARENT-SHAPE
      classes:
        - name: class-default
          actions:
            - type: shape
              shape_average_bit_rate: 20000000
            - type: service-policy
              service_policy: CHILD-QOS
```

Closes #338