### PR TITLE
fix: drop redundant ethernets.managed default (breaks interface render after #315)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module "iosxe" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_iosxe"></a> [iosxe](#requirement\_iosxe) | ~> 0.18.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.5.0, < 3.0.0 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.2, < 3.0.0 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -4,7 +4,3 @@ defaults:
       order: 0
     devices:
       managed: true
-      configuration:
-        interfaces:
-          ethernets:
-            managed: true

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     utils = {
       source  = "netascode/utils"
-      version = ">= 2.0.0, < 3.0.0"
+      version = ">= 2.0.2, < 3.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## What

Remove the `configuration.interfaces.ethernets.managed: true` entry from `defaults/defaults.yaml`.

## Why

#315 swapped the device-model engine from the `model` submodule to `provider::utils::render_device_configs`. The new engine merges defaults at the structure level, so for any device that defines no ethernets, `interfaces.ethernets` becomes the object `{managed = true}` instead of staying an absent/empty list. `iosxe_interfaces.tf` then does `for int in …interfaces.ethernets`, iterates that object's values, and `int` binds to the bool `true` → `Can't access attributes on a primitive-typed value (bool)` (line 33/35) and `keys(int)` "must have map or object type" (line 294). This is why master fails on every fixture whose device has no ethernets.

It's the only per-item default in `defaults.yaml`, and `managed` is already defaulted per-interface in the HCL (`managed = try(int.managed, true)`), so the entry is redundant — removing it restores the absent-list path without changing behavior.

## Scope

This is one of two issues from #315. The other (empty provider host) is fixed in netascode/terraform-provider-utils#177 (`buildProviderDevices` was dropping `host`). Both are required. 
Verified together against a live IOS-XE device: plan + apply/destroy clean for no-ethernet, loopback/port-channel, and ethernets-list fixtures.