### PR TITLE
fix(defaults): re-drop redundant ethernets.managed default

### DIFF
--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -4,7 +4,3 @@ defaults:
       order: 0
     devices:
       managed: true
-      configuration:
-        interfaces:
-          ethernets:
-            managed: true


### PR DESCRIPTION
Re-drop the redundant `configuration.interfaces.ethernets.managed` default.

Same change as #343: the scalar `ethernets.managed: true` collapses `interfaces.ethernets` into a map for devices that define no ethernets, so the interface locals iterate a map and `int` evaluates to a bool — breaking `iosxe_interfaces.tf` at `terraform apply` (`Can't access attributes on a primitive-typed value (bool)`). `managed` already defaults to true per-interface via `try(int.managed, true)`, so this default is redundant.

#343 removed it, but a later defaults regeneration re-added it. The upstream defaults source has since been corrected, so this removal should hold this time.