### PR TITLE
revert: remove username/password module variables (#344)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ module "iosxe" {
 | <a name="input_managed_device_groups"></a> [managed\_device\_groups](#input\_managed\_device\_groups) | List of device group names to be managed. By default all device groups will be managed. | `list(string)` | `[]` | no |
 | <a name="input_managed_devices"></a> [managed\_devices](#input\_managed\_devices) | List of device names to be managed. By default all devices will be managed. | `list(string)` | `[]` | no |
 | <a name="input_model"></a> [model](#input\_model) | As an alternative to YAML files, a native Terraform data structure can be provided as well. | `map(any)` | `{}` | no |
-| <a name="input_password"></a> [password](#input\_password) | Password for the IOS-XE devices. Can also be set using the IOSXE\_PASSWORD environment variable. | `string` | `null` | no |
 | <a name="input_save_config"></a> [save\_config](#input\_save\_config) | Write changes to startup-config on all devices. | `bool` | `false` | no |
 | <a name="input_template_directories"></a> [template\_directories](#input\_template\_directories) | List of paths to directories containing template files. | `list(string)` | `[]` | no |
 | <a name="input_template_files"></a> [template\_files](#input\_template\_files) | List of paths to template files. | `list(string)` | `[]` | no |
-| <a name="input_username"></a> [username](#input\_username) | Username for the IOS-XE devices. Can also be set using the IOSXE\_USERNAME environment variable. | `string` | `null` | no |
 | <a name="input_write_model_file"></a> [write\_model\_file](#input\_write\_model\_file) | Write the full model including all resolved templates to a single YAML file. Value is a path pointing to the file to be created. | `string` | `""` | no |
 | <a name="input_yaml_directories"></a> [yaml\_directories](#input\_yaml\_directories) | List of paths to YAML directories. | `list(string)` | `[]` | no |
 | <a name="input_yaml_files"></a> [yaml\_files](#input\_yaml\_files) | List of paths to YAML files. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,6 @@ locals {
 }
 
 provider "iosxe" {
-  username    = var.username
-  password    = var.password
   devices     = local.rendered.provider_devices
   auto_commit = var.device_transaction ? false : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,3 @@
-variable "username" {
-  description = "Username for the IOS-XE devices. Can also be set using the IOSXE_USERNAME environment variable."
-  type        = string
-  default     = null
-}
-
-variable "password" {
-  description = "Password for the IOS-XE devices. Can also be set using the IOSXE_PASSWORD environment variable."
-  type        = string
-  default     = null
-  sensitive   = true
-}
-
 variable "yaml_directories" {
   description = "List of paths to YAML directories."
   type        = list(string)


### PR DESCRIPTION
## Summary

Reverts #344 (`feat: add username/password passthrough to provider block`).

As noted in [Daniel's review comment](https://github.com/netascode/terraform-iosxe-nac-iosxe/pull/344#issuecomment-4857069294), passing credentials as module input variables causes them to be written to Terraform state in plaintext. The `sensitive = true` flag only masks values in CLI output — it does not prevent state storage. Users may not be aware of this behavior, creating a security risk.

The existing environment variable approach (`IOSXE_USERNAME` / `IOSXE_PASSWORD`) avoids state storage entirely and remains the supported mechanism for supplying credentials.

A follow-up documentation update will clarify this requirement in the Network as Code documentation site.

## What this reverts

- Removes `username` and `password` input variables from the module
- Removes the passthrough of those variables to the internal `provider "iosxe" {}` block
- Removes the corresponding entries from the README inputs table

## Test plan

- [x] `terraform validate` — no functional change to existing env-var users
- [x] Backward compatible — env vars continue to work as before

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: revert commit + PR documentation
- **Human Oversight**: Directed by Christopher Hart