### PR TITLE
fix(object_groups): pass service protocol_numbers as int set, not objects

### DIFF
--- a/iosxe_object_groups.tf
+++ b/iosxe_object_groups.tf
@@ -36,9 +36,7 @@ locals {
         group_objects = try(length(og.group_objects) == 0, true) ? null : [for g in og.group_objects : {
           group_name = g
         }]
-        protocol_numbers = try(length(og.protocol_numbers) == 0, true) ? null : [for n in og.protocol_numbers : {
-          number = n
-        }]
+        protocol_numbers          = try(length(og.protocol_numbers) == 0, true) ? null : og.protocol_numbers
         ahp                       = try(og.ahp, null)
         eigrp                     = try(og.eigrp, null)
         esp                       = try(og.esp, null)


### PR DESCRIPTION
## Summary

Fix a type mismatch in the `object_groups_service` mapping that made any service object group with `protocol_numbers` fail at plan time.

## Root cause

The `iosxe_object_group` resource models `service.protocol_numbers` as an **`Int64Set`** (a set of integers). The module built it as a list of objects:

```hcl
protocol_numbers = ... : [for n in og.protocol_numbers : { number = n }]
```

which produced:

```
Error: Incorrect attribute value type
  Inappropriate value for attribute "service": element 0: attribute
  "protocol_numbers": element 0: number required, but have object.
```

The fix passes the raw integer list, which coerces to the expected set:

```hcl
protocol_numbers = try(length(og.protocol_numbers) == 0, true) ? null : og.protocol_numbers
```

## How it was found

Surfaced by an integration run that exercised a service object group with `protocol_numbers` for the first time end-to-end (the attribute had no prior fixture coverage). This is the only scalar-set attribute in the service block — the `Int64Set` type appears exactly once — so every other service attribute (booleans and the `Set`-of-objects port lists) is unaffected.

## Testing

- `terraform fmt`, `tflint`, and `terraform-docs` pass.
- End-to-end validation is via the downstream nac-iosxe pipeline, which consumes this module's `main` and applies service object groups against real devices.
