### PR TITLE
fix(interfaces): Add device_tracking / device_tracking_attached_policies to port_…

### DIFF
--- a/iosxe_interfaces.tf
+++ b/iosxe_interfaces.tf
@@ -1941,6 +1941,8 @@ resource "iosxe_interface_port_channel" "port_channel" {
   load_interval                            = each.value.load_interval
   snmp_trap_link_status                    = each.value.snmp_trap_link_status
   logging_event_link_status_enable         = each.value.logging_event_link_status_enable
+  device_tracking                          = each.value.device_tracking
+  device_tracking_attached_policies        = each.value.device_tracking_attached_policies
   switchport                               = each.value.switchport
   auto_qos_classify                        = each.value.auto_qos_classify
   auto_qos_classify_police                 = each.value.auto_qos_classify_police


### PR DESCRIPTION
Hi,

I noticed that `port_channels` was missing `device_tracking` capabilities that `ethernets` had. When using device-tracking it's fairly important to be able to disable tracking on uplink/trunks so as not to overwhelm the switch with new clients, and the network with probes.

An easy fix compared to my provider PRs...

Let me know if I can do anything!

David

## ✔️ Type of Change

- [ ] 🚀 New feature (new Terraform resource/module file, new HCL logic)
- [x] 🐛 Bug fix (corrects an issue in module HCL, dependencies, or locals)
- [ ] ⚠️ Breaking change (modifies existing module interface or variable structure)
- [ ] 📄 Documentation update (README, examples)
- [ ] 🛠️ Refactoring / tech debt (internal improvements, no user-facing changes)
- [ ] ⚙️ Other (please describe):

## 🔗 Related Issue(s)

Fixes #353

## 📝 Proposed Changes

`iosxe_interface_port_channel`'s resource block in `iosxe_interfaces.tf` was missing the `device_tracking` and `device_tracking_attached_policies` wiring that the equivalent Ethernet resource block already has. Both attributes are already parsed from the YAML data model and already supported by the provider schema — this PR just adds the two lines connecting `each.value.device_tracking` / `each.value.device_tracking_attached_policies` to the port-channel resource block, matching the existing Ethernet pattern.

No schema changes, no new variables — this restores parity that should already have existed between the two interface types.

---

## 🧪 Testing Evidence

- [ ] N/A — this PR does not touch `.tf` files (e.g., docs-only, CI, chore)

### Terraform Validation

```
module.nac-iosxe.iosxe_interface_port_channel.port_channel["C9200L-24P-4G/Port-channel1"]: Refreshing state... [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.nac-iosxe.iosxe_interface_port_channel.port_channel["C9200L-24P-4G/Port-channel1"] will be updated in-place
  ~ resource "iosxe_interface_port_channel" "port_channel" {
      + device_tracking                   = true
      + device_tracking_attached_policies = [
          + {
              + name = "DISABLE-IP-TRACKING"
            },
        ]
        id                                = "Cisco-IOS-XE-native:native/interface/Port-channel=1"
        name                              = 1
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
module.nac-iosxe.iosxe_interface_port_channel.port_channel["C9200L-24P-4G/Port-channel1"]: Modifying... [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]
module.nac-iosxe.iosxe_interface_port_channel.port_channel["C9200L-24P-4G/Port-channel1"]: Modifications complete after 3s [id=Cisco-IOS-XE-native:native/interface/Port-channel=1]
module.nac-iosxe.iosxe_commit.commit["C9200L-24P-4G"]: Modifying...
module.nac-iosxe.iosxe_commit.commit["C9200L-24P-4G"]: Modifications complete after 2s

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

- [x] `terraform validate` passes
- [x] `terraform plan` produces expected changes (or `terraform apply` on a test device)

Hardware-validated on `Port-channel1`, lab C9200L, IOS-XE 17.15.4: `device_tracking` and `device_tracking_attached_policies` both applied and confirmed via `show running-config interface Port-channel1 | include device-tracking`.

Note: applying this config triggers a CLI-to-NETCONF datastore resync on the device — consistent with other known resync triggers, not specific to this change.

---

## 🔗 Cross-Repo Links

- Provider PR/release this depends on: none — uses existing provider-schema support
- Schema PR: none

## ✅ Checklist

### Pre-Submission

- [x] I have merged/rebased from `main` and resolved all merge conflicts
- [x] `terraform validate` passes
- [x] Module changes have been tested with `terraform plan` or `terraform apply`

### Code Quality

- [ ] New `.tf` file(s) follow existing module patterns (`for_each`, `try()` hierarchy, `depends_on`) - No new `.tf` files created.
- [ ] Variable references use the `local.device_config` → `local.defaults` fallback pattern - No new variable references
- [x] No hardcoded values — all config comes from the YAML data model

### Labels & Assignment

- [ ] I have assigned at least one label that aligns with `release.yaml` categories: `feature`, `enhancement`, `bug`, `fix`, `breaking-change`, `documentation`, `refactor`, `tech-debt`, `chore`, or `dependencies`
- [ ] Label(s) match the linked GitHub issue label(s) where applicable
- [ ] PR is assigned to myself
- [ ] One or more reviewers are assigned